### PR TITLE
Fix bug with transaction message processing

### DIFF
--- a/bin/start-libbitcoind.js
+++ b/bin/start-libbitcoind.js
@@ -12,7 +12,7 @@ process.title = 'libbitcoind';
  */
 var daemon = require('../').daemon({
   datadir: process.env.BITCORENODE_DIR || '~/.bitcoin',
-  network: process.env.BITCORENODE_NETWORK || 'testnet'
+  network: process.env.BITCORENODE_NETWORK || 'livenet'
 });
 
 daemon.on('ready', function() {


### PR DESCRIPTION
- Copy the message so that the message can be later processed
- Connect at the front to be able to scan but not seek
- Emit event after process message and accept to mempool
- Include node buffer, hash and mempool status of the transaction in result
- Fixes https://github.com/bitpay/bitcore-node/issues/92