### PR TITLE
No curl

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -10,10 +10,20 @@ binary_url="https://${bucket_name}.s3.amazonaws.com/${tarball_name}"
 
 echo "Downloading binary: ${binary_url}"
 
-curl --fail -I $binary_url
+is_curl=true
+if hash curl 2>/dev/null; then
+  curl --fail -I $binary_url
+else
+  is_curl=false
+  wget --server-response --spider $binary_url
+fi
 
 if test $? -eq 0; then
-  curl $binary_url > $tarball_name
+  if [ "${is_curl}" = true ]; then
+    curl $binary_url > $tarball_name
+  else
+    wget $binary_url
+  fi
   if test -e "${tarball_name}"; then
     echo "Unpacking binary distribution"
     tar -xvzf $tarball_name

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bitcore-node",
   "description": "Full node with extended capabilities using Bitcore and Bitcoin Core",
   "author": "BitPay <dev@bitpay.com>",
-  "version": "0.2.0-beta.2",
+  "version": "0.2.0-dev",
   "main": "./index.js",
   "repository": "git://github.com/bitpay/bitcore-node.git",
   "homepage": "https://github.com/bitpay/bitcore-node.js",


### PR DESCRIPTION
in almost call cases someone will have EITHER curl or wget. More common is curl (and possibly only curl), but in some rare cases only wget exists. If this is the case (as it is in Ubuntu 12.04), use wget.