### PR TITLE
setImmediate when using c++ bindings

### DIFF
--- a/integration/regtest.js
+++ b/integration/regtest.js
@@ -93,54 +93,53 @@ describe('Daemon Binding Functionality', function() {
         // Generate enough blocks so that the initial coinbase transactions
         // can be spent.
 
-        client.generate(150, function(err, response) {
+        setImmediate(function() {
+          client.generate(150, function(err, response) {
+            if (err) {
+              throw err;
+            }
+            blockHashes = response.result;
 
-          if (err) {
-            throw err;
-          }
-          blockHashes = response.result;
+            log.info('Preparing test data...');
 
-          log.info('Preparing test data...');
+            // Get all of the unspent outputs
+            client.listUnspent(0, 150, function(err, response) {
+              utxos = response.result;
 
-          // Get all of the unspent outputs
-          client.listUnspent(0, 150, function(err, response) {
-            utxos = response.result;
-
-            async.mapSeries(utxos, function(utxo, next) {
-              async.series([
-                function(finished) {
-                  // Load all of the transactions for later testing
-                  client.getTransaction(utxo.txid, function(err, txresponse) {
-                    if (err) {
-                      throw err;
-                    }
-                    // add to the list of transactions for testing later
-                    transactionData.push(txresponse.result.hex);
-                    finished();
-                  });
-                },
-                function(finished) {
-                  // Get the private key for each utxo
-                  client.dumpPrivKey(utxo.address, function(err, privresponse) {
-                    if (err) {
-                      throw err;
-                    }
-                    utxo.privateKeyWIF = privresponse.result;
-                    finished();
-                  });
+              async.mapSeries(utxos, function(utxo, next) {
+                async.series([
+                  function(finished) {
+                    // Load all of the transactions for later testing
+                    client.getTransaction(utxo.txid, function(err, txresponse) {
+                      if (err) {
+                        throw err;
+                      }
+                      // add to the list of transactions for testing later
+                      transactionData.push(txresponse.result.hex);
+                      finished();
+                    });
+                  },
+                  function(finished) {
+                    // Get the private key for each utxo
+                    client.dumpPrivKey(utxo.address, function(err, privresponse) {
+                      if (err) {
+                        throw err;
+                      }
+                      utxo.privateKeyWIF = privresponse.result;
+                      finished();
+                    });
+                  }
+                ], next);
+              }, function(err) {
+                if (err) {
+                  throw err;
                 }
-              ], next);
-            }, function(err) {
-              if (err) {
-                throw err;
-              }
-              done();
+                done();
+              });
             });
           });
         });
-
       });
-
     });
   });
 

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -117,7 +117,7 @@ Bitcoin.prototype._onReady = function(result, callback) {
     self.genesisBuffer = block;
     self.emit('ready', result);
     log.info('Bitcoin Daemon Ready');
-    setImmediate(callback);
+    callback();
   });
 
 };

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -194,14 +194,12 @@ Bitcoin.prototype.getInfo = function() {
 
 Bitcoin.prototype.stop = function(callback) {
   return bindings.stop(function(err, status) {
-    setImmediate(function() {
-      if (err) {
-        return callback(err);
-      } else {
-        log.info(status);
-        return callback();
-      }
-    });
+    if (err) {
+      return callback(err);
+    } else {
+      log.info(status);
+      return callback();
+    }
   });
 };
 


### PR DESCRIPTION
The bindings have been overhauled to take advantage of the following:
- encapsulated isolate scopes (isolates are passed in the async structs)
- persistent functions can now be used instead of Eternal functions
- casts to async data structs are now being made using reinterpret_cast instead of static_cast