### PR TITLE
Push a specific tag in release notes.

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -55,5 +55,5 @@ Create a release tag and push it to the BitPay Github repo:
 
 ```bash
 git tag <version>
-git push upstream --tags
+git push upstream <version>
 ```


### PR DESCRIPTION
In order to ensure that non-related tags do not get pushed to upstream, I altered the command to push the tag.