### PR TITLE
Reindex logic

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -74,8 +74,9 @@ Bitcoin.prototype._loadConfiguration = function() {
 
   if (this.configuration.reindex && this.configuration.reindex === 1) {
     log.warn('Reindex option is currently enabled. This means that bitcoind is undergoing a reindex. ' +
-      'Once the reindex is complete, the rest of bitcore-node services will start. ' +
-      'WARNING!!! Be sure to remove \'reindex=1\' from your bitcoin.conf -BEFORE- restarting bitcore-node.');
+      'The reindex flag will start the index from beginning every time the node is started, so it ' +
+      'should be removed after the reindex has been initiated. Once the reindex is complete, the rest ' +
+      'of bitcore-node services will start.');
     this._reindex = true;
   }
 

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -22,6 +22,8 @@ function Bitcoin(options) {
     return new Bitcoin(options);
   }
 
+  this._reindex = false;
+  this._reindexWait = 1000;
   Service.call(this, options);
   $.checkState(this.node.datadir, 'Node is missing datadir property');
 }
@@ -69,6 +71,14 @@ Bitcoin.prototype._loadConfiguration = function() {
       'Please add "txindex=1" to your configuration and reindex an existing database if ' +
       'necessary with reindex=1'
   );
+
+  if (this.configuration.reindex && this.configuration.reindex === 1) {
+    log.warn('Reindex option is currently enabled. This means that bitcoind is undergoing a reindex. ' +
+      'Once the reindex is complete, the rest of bitcore-node services will start. ' +
+      'WARNING!!! Be sure to remove \'reindex=1\' from your bitcoin.conf -BEFORE- restarting bitcore-node.');
+    this._reindex = true;
+  }
+
 };
 
 Bitcoin.prototype._onTipUpdate = function(result) {
@@ -139,7 +149,21 @@ Bitcoin.prototype.start = function(callback) {
       if (err) {
         return callback(err);
       }
-      self._onReady(result, callback);
+      if (self._reindex) {
+        var interval = setInterval(function() {
+          var percentSynced = bindings.syncPercentage();
+          log.info("Bitcoin Core Daemon Reindex Percentage: " + percentSynced);
+          if (percentSynced >= 100) {
+            self._reindex = false;
+            self._onReady(result, callback);
+            clearInterval(interval);
+          }
+        }, self._reindexWait);
+
+      }
+      else {
+        self._onReady(result, callback);
+      }
     });
   });
 };


### PR DESCRIPTION
- If the reindex option is set in bitcoin.conf, then when start is called and onBlocksReady's callback is fired:
	- start's callback will not be fired until the reindex takes place.
	- along the way the sync percentage is display once per second