### PR TITLE
Added a check for the right number of tip events.

### DIFF
--- a/integration/regtest.js
+++ b/integration/regtest.js
@@ -280,8 +280,10 @@ describe('Daemon Binding Functionality', function() {
     it('will get an event when the tip is new', function(done) {
       this.timeout(4000);
       bitcoind.on('tip', function(height) {
-        height.should.equal(151);
-        done();
+        if (height == 151) {
+          height.should.equal(151);
+          done();
+        }
       });
       client.generate(1, function(err, response) {
         if (err) {


### PR DESCRIPTION
- Since we have a spin lock that leads to the callback from a tip update, there could be cases where the callback assigned to a tip update isn't the one matching the last generate.
- The architectural decision is to leave the spin lock in place to lower the number of possible callbacks for tip updates.