### PR TITLE
WIP Change to use bitcore as a peerDependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "async": "^1.3.0",
     "bindings": "^1.2.1",
-    "bitcore": "^0.13.0",
     "body-parser": "^1.13.3",
     "colors": "^1.1.2",
     "commander": "^2.8.1",
@@ -62,6 +61,9 @@
     "semver": "^5.0.1",
     "socket.io": "^1.3.6",
     "socket.io-client": "^1.3.6"
+  },
+  "peerDependency": {
+    "bitcore": "^0.13.0"
   },
   "devDependencies": {
     "aws-sdk": "~2.0.0-rc.15",


### PR DESCRIPTION
From tests using peerDependency will install the dependency with a global install, however when required in a package.json it will give a warning that a dependency isn't meet.