### PR TITLE
gitignore, integration test, env

### DIFF
--- a/bin/start.js
+++ b/bin/start.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 'use strict';
 
 var start = require('../lib/scaffold/start');

--- a/integration/data/.gitignore
+++ b/integration/data/.gitignore
@@ -1,0 +1,3 @@
+.lock
+blocks
+regtest

--- a/test/bus.integration.js
+++ b/test/bus.integration.js
@@ -1,0 +1,92 @@
+var Service = require('../lib/service');
+var BitcoreNode = require('../lib/node');
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
+var should = require('chai').should();
+
+var TestService = function(options) {
+  this.node = options.node;
+}
+util.inherits(TestService, Service);
+TestService.dependencies = [];
+
+TestService.prototype.start = function(callback) {
+  callback();
+};
+TestService.prototype.stop = function(callback) {
+  callback();
+};
+TestService.prototype.close = function(callback) {
+  callback();
+};
+TestService.prototype.getPublishEvents = function() {
+  return [
+    {
+      name: 'test/testEvent',
+      scope: this,
+      subscribe: this.subscribe.bind(this, 'test/testEvent'),
+      unsubscribe: this.unsubscribe.bind(this, 'test/testEvent')
+    }
+  ];
+};
+
+TestService.prototype.subscribe = function(name, emitter, params) {
+  emitter.emit(name, params);
+};
+
+TestService.prototype.unsubscribe = function(name, emitter) {
+  emitter.emit('unsubscribe');
+};
+
+
+describe('Bus Functionality', function() {
+  it('should subscribe to testEvent', function(done) {
+    var node = new BitcoreNode({
+      datadir: './',
+      network: 'testnet',
+      port: 8888,
+      services: [
+        {
+          name: 'testService',
+          config: {},
+          module: TestService
+        }
+      ]
+    });
+    node.start(function() {
+      var bus = node.openBus();
+      var params = 'somedata';
+      bus.on('test/testEvent', function(data) {
+        data.should.be.equal(params);
+        done();
+      });
+      bus.subscribe('test/testEvent', params);
+    });
+  });
+
+  it('should unsubscribe from a testEvent', function(done) {
+    var node = new BitcoreNode({
+      datadir: './',
+      network: 'testnet',
+      port: 8888,
+      services: [
+        {
+          name: 'testService',
+          config: {},
+          module: TestService
+        }
+      ]
+    });
+    node.start(function() {
+      var bus = node.openBus();
+      var params = 'somedata';
+      bus.on('unsubscribe', function() {
+        done();
+      });
+      bus.subscribe('test/testEvent');
+      bus.unsubscribe('test/testEvent');
+
+    });
+
+  });
+});


### PR DESCRIPTION
- Added a very common way to launch a script using the env (saving keystrokes)
- Added a gitignore for the integration/data dir
- Added a bus integration test apart from the regtest and using a test service