### PR TITLE
GetBlockIndex segmentation fault with genesis block

### DIFF
--- a/integration/regtest.js
+++ b/integration/regtest.js
@@ -231,6 +231,11 @@ describe('Daemon Binding Functionality', function() {
         blockIndex.height.should.equal(i + 1);
       });
     });
+    it('will get null prevHash for the genesis block', function() {
+      var blockIndex = bitcoind.getBlockIndex(0);
+      should.exist(blockIndex);
+      should.equal(blockIndex.prevHash, null);
+    });
   });
 
   describe('get block index by height', function() {

--- a/src/libbitcoind.cc
+++ b/src/libbitcoind.cc
@@ -1337,14 +1337,20 @@ NAN_METHOD(GetBlockIndex) {
     }
   }
 
+  Local<Object> obj = NanNew<Object>();
+
   arith_uint256 cw = blockIndex->nChainWork;
   CBlockIndex* prevBlockIndex = blockIndex->pprev;
-  const uint256* prevHash = prevBlockIndex->phashBlock;
+  if (&prevBlockIndex->phashBlock != 0) {
+    const uint256* prevHash = prevBlockIndex->phashBlock;
+    obj->Set(NanNew<String>("prevHash"), NanNew<String>(prevHash->GetHex()));
+  } else {
+    obj->Set(NanNew<String>("prevHash"), NanNull());
+  }
 
-  Local<Object> obj = NanNew<Object>();
   obj->Set(NanNew<String>("hash"), NanNew<String>(blockIndex->phashBlock->GetHex()));
   obj->Set(NanNew<String>("chainWork"), NanNew<String>(cw.GetHex()));
-  obj->Set(NanNew<String>("prevHash"), NanNew<String>(prevHash->GetHex()));
+
   obj->Set(NanNew<String>("height"), NanNew<Number>(blockIndex->nHeight));
 
   NanReturnValue(obj);


### PR DESCRIPTION
Fixes an bug where accessing `prevBlockIndex->phashBlock` for the
genesis block would cause a segmentation fault with an error of
"Cannot access memory at address 0x0". As the genesis block doesn't
have a previous hash, it will now set the "prevHash" to "null".