### PR TITLE
isSpent logic

### DIFF
--- a/integration/regtest-node.js
+++ b/integration/regtest-node.js
@@ -723,7 +723,8 @@ describe('Node Functionality', function() {
         result.should.equal(true);
         done();
       });
-      it('will incorrectly return false for an input that is spent in an unconfirmed transaction', function(done) {
+      //CCoinsViewMemPool only checks for spent outputs that are not the mempool
+      it('will correctly return false for an input that is spent in an unconfirmed transaction', function(done) {
         node.services.address.getUnspentOutputs(address, false, function(err, results) {
           if (err) {
             throw err;


### PR DESCRIPTION
closes #245 
- Bitcoind's CCoinsViewMempool brings the mempool into view, but will not consider outputs therein as spent
- Changed the test description to match what is happening in that view
- Once a given tx has one confirmation, then isSpent will be true for those outputs