### PR TITLE
ARM, Win32, Win64 Support

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -4,6 +4,7 @@ options=`cat ${root_dir}/bin/config_options.sh`
 depends_dir=$($root_dir/bin/variables.sh depends_dir)
 host=$(${root_dir}/bin/variables.sh host)
 btc_dir="${root_dir}/libbitcoind"
+sys=$($root_dir/bin/variables.sh sys)
 patch_sha=$($root_dir/bin/variables.sh patch_sha)
 export CPPFLAGS="-I${depends_dir}/${host}/include/boost -I${depends_dir}/${host}/include -L${depends_dir}/${host}/lib"
 echo "Using BTC directory: ${btc_dir}"
@@ -154,8 +155,11 @@ apply the current patch from "${root_dir}"/etc/bitcoin.patch? (y/N): "
   ./autogen.sh || exit -1
 
   boost_libdir="--with-boost-libdir=${depends_dir}/${host}/lib"
+  ldflags="LDFLAGS=-L${depends_dir}/${host}/lib"
+  cflags="CFLAGS=-I${depends_dir}/${host}/include"
+  config_host="--host ${host}"
 
-  full_options="${options} ${boost_libdir}"
+  full_options="${options} ${ldflags} ${cflags} ${config_host} ${boost_libdir}"
   echo "running the configure script with the following options:\n :::[\"${full_options}\"]:::"
   ${full_options}
 
@@ -182,4 +186,5 @@ if test x"$1" = x'debug'; then
   debug=--debug
 fi
 
-node-gyp ${debug} rebuild
+echo "running::: 'node-gyp ${sys} ${debug} rebuild'"
+node-gyp ${sys} ${debug} rebuild

--- a/bin/variables.sh
+++ b/bin/variables.sh
@@ -24,6 +24,11 @@ get_host_and_platform () {
   else
     platform=`uname -a | awk '{print tolower($1)}'`
     arch=`uname -m`
+    #for arm architectures, in order to get the right compiler later, use a predefined host
+    if [ "${arch:0:3}" == "arm" ]; then
+      platform="linux-gnueabihf"
+      arch="arm"
+    fi
   fi
 }
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -96,13 +96,47 @@ npm start
 This will then start the syncing process for Bitcoin Core and the extended capabilities as provided by the built-in Address Module (details below).
 
 
-## Cross-Compiling for ARM processors such as Android devices and Raspberry Pi-type devices
+## Cross-Compiling
 
-Bitcore-node has been tested on recent ARM processors like ARM CORTEX-A7 on Linux variants. We've tested Bitcore-node with armhf (hardware floating point support). It is much easier to cross-compile on a faster computer and transfer to the target device. Please refer to: https://wiki.debian.org/CrossToolchains. The following is the command to run on a linux build computer for a linux-based Raspberry Pi.
+### ARM processors such as Android devices and Raspberry Pi-type devices
+
+Bitcore-node has been tested on recent ARM processors like ARM CORTEX-A7 on Linux variants. We've tested Bitcore-node with armhf (hardware floating point support). It is much easier to cross-compile on a faster computer and transfer to the target device. Please refer to: https://wiki.debian.org/CrossToolchains.
+
+### Installation of Cross-compiling Toolkits on Ubuntu:
+
+```bash
+sudo apt-get install gcc-multilib
+sudo apt-get install gcc-arm-linux-gnueabihf
+sudo apt-get install g++-arm-linux-gnueabihf
+```
+
+The following is the command to run on a linux build computer for a linux-based Raspberry Pi.
 
 ```bash
 CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ npm install #note the CC and CXX environment variables
 scp build/Release/bitcoind.node <user>@<arm host>:<dir of bitcore-node>/build/Release
+```
+
+### Windows - 32 and 64 bit
+
+Bitcore-node has been tested on 32 and 64 bit processors and can be cross-compiled on a Linux computer for Windows hosts. This process is MUCH easier than installing all the build tools on a Windows host.
+
+### Installation of Cross-compiling Toolkits on Debian-like hosts:
+
+```bash
+sudo apt-get install mingw-w64 mingw-w64-tools
+```
+
+The following is the command to run on a linux build computer for a Windows 64 bit build.
+
+```bash
+CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ npm install
+```
+
+The following is the command to run on a linux build computer for a Windows 32 bit build.
+
+```bash
+CC=i686-w64-mingw32-gcc CXX=i686-w64-mingw32-g++ npm install
 ```
 
 Once everything is built, you can run bitcore-node via:

--- a/docs/build.md
+++ b/docs/build.md
@@ -93,6 +93,9 @@ Once everything is built, you can run bitcore-node via:
 npm start
 ```
 
+This will then start the syncing process for Bitcoin Core and the extended capabilities as provided by the built-in Address Module (details below).
+
+
 ## Cross-Compiling for ARM processors such as Android devices and Raspberry Pi-type devices
 
 Bitcore-node has been tested on recent ARM processors like ARM CORTEX-A7 on Linux variants. We've tested Bitcore-node with armhf (hardware floating point support). It is much easier to cross-compile on a faster computer and transfer to the target device. Please refer to: https://wiki.debian.org/CrossToolchains. The following is the command to run on a linux build computer for a linux-based Raspberry Pi.
@@ -102,5 +105,10 @@ CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ npm install #note the CC 
 scp build/Release/bitcoind.node <user>@<arm host>:<dir of bitcore-node>/build/Release
 ```
 
+Once everything is built, you can run bitcore-node via:
+
+```bash
+npm start
+```
 
 This will then start the syncing process for Bitcoin Core and the extended capabilities as provided by the built-in Address Module (details below).

--- a/docs/build.md
+++ b/docs/build.md
@@ -93,4 +93,14 @@ Once everything is built, you can run bitcore-node via:
 npm start
 ```
 
+## Cross-Compiling for ARM processors such as Android devices and Raspberry Pi-type devices
+
+Bitcore-node has been tested on recent ARM processors like ARM CORTEX-A7 on Linux variants. We've tested Bitcore-node with armhf (hardware floating point support). It is much easier to cross-compile on a faster computer and transfer to the target device. Please refer to: https://wiki.debian.org/CrossToolchains. The following is the command to run on a linux build computer for a linux-based Raspberry Pi.
+
+```bash
+CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ npm install #note the CC and CXX environment variables
+scp build/Release/bitcoind.node <user>@<arm host>:<dir of bitcore-node>/build/Release
+```
+
+
 This will then start the syncing process for Bitcoin Core and the extended capabilities as provided by the built-in Address Module (details below).

--- a/etc/bitcoin.patch
+++ b/etc/bitcoin.patch
@@ -139,23 +139,22 @@ index e7aa48d..df0f7ae 100644
  endef
 
 diff --git a/src/Makefile.am b/src/Makefile.am
-index 1c2f770..5582b7e 100644
+index 1c2f770..b6ddc16 100644
 --- a/src/Makefile.am
 +++ b/src/Makefile.am
-@@ -1,6 +1,12 @@
+@@ -1,6 +1,11 @@
  DIST_SUBDIRS = secp256k1
  AM_LDFLAGS = $(PTHREAD_CFLAGS) $(LIBTOOL_LDFLAGS)
 
 +noinst_LTLIBRARIES =
 +libbitcoind_la_LIBADD =
 +libbitcoind_la_LDFLAGS = -no-undefined
-+STATIC_BOOST_LIBS =
 +STATIC_BDB_LIBS =
-+STATIC_EXTRA_LIBS = $(STATIC_BOOST_LIBS) $(LIBLEVELDB) $(LIBMEMENV)
++STATIC_EXTRA_LIBS = $(LIBLEVELDB) $(LIBMEMENV)
 
  if EMBEDDED_LEVELDB
  LEVELDB_CPPFLAGS += -I$(srcdir)/leveldb/include
-@@ -15,6 +21,7 @@ $(LIBLEVELDB) $(LIBMEMENV):
+@@ -15,6 +20,7 @@ $(LIBLEVELDB) $(LIBMEMENV):
  	@echo "Building LevelDB ..." && $(MAKE) -C $(@D) $(@F) CXX="$(CXX)" \
  	  CC="$(CC)" PLATFORM=$(TARGET_OS) AR="$(AR)" $(LEVELDB_TARGET_FLAGS) \
            OPT="$(CXXFLAGS) $(CPPFLAGS) -D__STDC_LIMIT_MACROS"
@@ -163,7 +162,7 @@ index 1c2f770..5582b7e 100644
  endif
 
  BITCOIN_CONFIG_INCLUDES=-I$(builddir)/config
-@@ -49,16 +56,16 @@ BITCOIN_INCLUDES += $(BDB_CPPFLAGS)
+@@ -49,16 +55,16 @@ BITCOIN_INCLUDES += $(BDB_CPPFLAGS)
  EXTRA_LIBRARIES += libbitcoin_wallet.a
  endif
 
@@ -187,7 +186,7 @@ index 1c2f770..5582b7e 100644
  if BUILD_BITCOIND
    bin_PROGRAMS += bitcoind
  endif
-@@ -66,6 +73,9 @@ endif
+@@ -66,6 +72,9 @@ endif
  if BUILD_BITCOIN_UTILS
    bin_PROGRAMS += bitcoin-cli bitcoin-tx
  endif
@@ -197,7 +196,7 @@ index 1c2f770..5582b7e 100644
 
  .PHONY: FORCE
  # bitcoin core #
-@@ -169,8 +179,11 @@ obj/build.h: FORCE
+@@ -169,8 +178,11 @@ obj/build.h: FORCE
  	@$(MKDIR_P) $(builddir)/obj
  	@$(top_srcdir)/share/genbuild.sh $(abs_top_builddir)/src/obj/build.h \
  	  $(abs_top_srcdir)
@@ -210,7 +209,7 @@ index 1c2f770..5582b7e 100644
  # server: shared between bitcoind and bitcoin-qt
  libbitcoin_server_a_CPPFLAGS = $(BITCOIN_INCLUDES) $(MINIUPNPC_CPPFLAGS)
  libbitcoin_server_a_SOURCES = \
-@@ -309,9 +322,18 @@ nodist_libbitcoin_util_a_SOURCES = $(srcdir)/obj/build.h
+@@ -309,9 +321,18 @@ nodist_libbitcoin_util_a_SOURCES = $(srcdir)/obj/build.h
  bitcoind_SOURCES = bitcoind.cpp
  bitcoind_CPPFLAGS = $(BITCOIN_INCLUDES)
  bitcoind_LDFLAGS = $(RELDFLAGS) $(AM_LDFLAGS) $(LIBTOOL_APP_LDFLAGS)
@@ -229,7 +228,7 @@ index 1c2f770..5582b7e 100644
  endif
 
  bitcoind_LDADD = \
-@@ -326,10 +348,21 @@ bitcoind_LDADD = \
+@@ -326,10 +347,20 @@ bitcoind_LDADD = \
 
  if ENABLE_WALLET
  bitcoind_LDADD += libbitcoin_wallet.a
@@ -237,7 +236,6 @@ index 1c2f770..5582b7e 100644
 +libbitcoind_la_SOURCES += $(libbitcoin_wallet_a_SOURCES)
  endif
 
-+STATIC_BOOST_LIBS += ../depends/$(ARCH_PLATFORM)/lib/libboost_filesystem-mt.a ../depends/$(ARCH_PLATFORM)/lib/libboost_system-mt.a ../depends/$(ARCH_PLATFORM)/lib/libboost_chrono-mt.a ../depends/$(ARCH_PLATFORM)/lib/libboost_thread-mt.a ../depends/$(ARCH_PLATFORM)/lib/libboost_program_options-mt.a
 +STATIC_BDB_LIBS += ../depends/$(ARCH_PLATFORM)/lib/libdb_cxx.a
 +
  bitcoind_LDADD += $(BOOST_LIBS) $(BDB_LIBS) $(SSL_LIBS) $(CRYPTO_LIBS) $(MINIUPNPC_LIBS)


### PR DESCRIPTION
closes #260 
- Added checks for CC or CXX env variables in order to build the right output files for arm computers.