### PR TITLE
Fixed bug with balance

### DIFF
--- a/lib/services/address/index.js
+++ b/lib/services/address/index.js
@@ -1048,8 +1048,12 @@ AddressService.prototype.getUnspentOutputsForAddress = function(address, queryMe
       return callback(new errors.NoOutputs('Address ' + address + ' has no outputs'), []);
     }
 
+    var opts = {
+      queryMempool: queryMempool
+    };
+
     var isUnspent = function(output, callback) {
-      self.isUnspent(output, callback);
+      self.isUnspent(output, opts, callback);
     };
 
     async.filter(outputs, isUnspent, function(results) {
@@ -1061,25 +1065,37 @@ AddressService.prototype.getUnspentOutputsForAddress = function(address, queryMe
 /**
  * Will give the inverse of isSpent
  * @param {Object} output
+ * @param {Object} options
+ * @param {Boolean} options.queryMempool - Include mempool in results
  * @param {Function} callback
  */
-AddressService.prototype.isUnspent = function(output, callback) {
-  this.isSpent(output, function(spent) {
+AddressService.prototype.isUnspent = function(output, options, callback) {
+  $.checkArgument(_.isFunction(callback));
+  this.isSpent(output, options, function(spent) {
     callback(!spent);
   });
 };
 
 /**
- * Will determine if an output is spent, results do not include the mempool.
+ * Will determine if an output is spent.
  * @param {Object} output - An output as returned from getOutputs
+ * @param {Object} options
+ * @param {Boolean} options.queryMempool - Include mempool in results
  * @param {Function} callback
  */
-AddressService.prototype.isSpent = function(output, callback) {
+AddressService.prototype.isSpent = function(output, options, callback) {
+  $.checkArgument(_.isFunction(callback));
+  var queryMempool = _.isUndefined(options.queryMempool) ? true : options.queryMempool;
   var self = this;
   var txid = output.prevTxId ? output.prevTxId.toString('hex') : output.txid;
-
+  var spent = self.node.services.bitcoind.isSpent(txid, output.outputIndex);
+  if (!spent && queryMempool) {
+    var spentIndexKey = [txid, output.outputIndex].join('-');
+    spent = self.mempoolSpentIndex[spentIndexKey] ? true : false;
+  }
   setImmediate(function() {
-    callback(self.node.services.bitcoind.isSpent(txid, output.outputIndex));
+    // TODO error should be the first argument?
+    callback(spent);
   });
 };
 
@@ -1179,7 +1195,7 @@ AddressService.prototype.getAddressSummary = function(address, options, callback
       var txids = [];
 
       for(var i = 0; i < outputs.length; i++) {
-        // Bitcoind's isSpent at the moment only works for confirmed transactions
+        // Bitcoind's isSpent only works for confirmed transactions
         var spentDB = self.node.services.bitcoind.isSpent(outputs[i].txid, outputs[i].outputIndex);
         var spentIndexKey = [outputs[i].txid, outputs[i].outputIndex].join('-');
         var spentMempool = self.mempoolSpentIndex[spentIndexKey];


### PR DESCRIPTION
There was a bug when getting unspent outputs that would include an output
that was spent in the mempool in addition to the new output with the change
address. This lead to a balance having an output counted twice towards the
end balance. The solution is to have the isSpent method for the address service
to also include if the output was spent in the mempool, as the isSpent
method exposed from bitcoind only includes if the output was spent in a block.