### PR TITLE
Fix bug where the outputIndex would be removed.

### DIFF
--- a/lib/services/address/index.js
+++ b/lib/services/address/index.js
@@ -870,8 +870,7 @@ AddressService.prototype.getInputs = function(addressStr, options, callback) {
       var mempoolInputs = self.mempoolInputIndex[addressStr];
       if (mempoolInputs) {
         for(var i = 0; i < mempoolInputs.length; i++) {
-          // TODO copy
-          var newInput = mempoolInputs[i];
+          var newInput = _.clone(mempoolInputs[i]);
           newInput.address = addressStr;
           newInput.height = -1;
           newInput.confirmations = 0;
@@ -984,8 +983,7 @@ AddressService.prototype.getOutputs = function(addressStr, options, callback) {
       var mempoolOutputs = self.mempoolOutputIndex[addressStr];
       if (mempoolOutputs) {
         for(var i = 0; i < mempoolOutputs.length; i++) {
-          // TODO copy
-          var newOutput = mempoolOutputs[i];
+          var newOutput = _.clone(mempoolOutputs[i]);
           newOutput.address = addressStr;
           newOutput.height = -1;
           newOutput.confirmations = 0;


### PR DESCRIPTION
The address history `combineTransactionInfo` method removes the
outputIndex when creating the outputIndexes property. When these are
from the mempool the original reference is also modified.

We can easily solve this by returning new instances in `getOutputs`
and `getInputs` instead of a reference to the actual mempool instance.

This will also have the additional benefit that height and other
properties that will be the same for every mempool entry will
not be stored in memory longer than what is necessary to fulfill
a request.

Closes: https://github.com/bitpay/bitcore-node/issues/294