### PR TITLE
Fix typos and add detailed documentation to services.md

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -4,7 +4,7 @@ description: Errors for Bitcore Node
 ---
 # Errors
 
-Many times there are cases where an error condition can be gracefully handled depending on a particular use. To assist in better error handling, errors will have different types so that it's possible to determine the type of error and handle appropriatly.
+Many times there are cases where an error condition can be gracefully handled depending on a particular use. To assist in better error handling, errors will have different types so that it's possible to determine the type of error and handle appropriately.
 
 ```js
 node.services.address.getUnspentOutputs('00000000839a8...', function(err, outputs) {

--- a/docs/services.md
+++ b/docs/services.md
@@ -116,10 +116,10 @@ us to index them. Let's take a look at an example where we will index the time t
 ```js
 //Index prefix, so that we can determine the difference between our index 
 //and the indexes provided by other services
-MyService.datePrefix = new Buffer('10');
+MyService.datePrefix = new Buffer('10', 'hex');
 
-MyService.minPosition = new Buffer('00000');
-MyService.maxPosition = new Buffer('99999');
+MyService.minPosition = new Buffer('00000', 'hex');
+MyService.maxPosition = new Buffer('99999', 'hex');
 
 //This function is automatically called when a block is added or receieved
 MyService.prototype.prototype.blockHandler = function(block, addOutput, callback) {
@@ -236,8 +236,8 @@ var index2value = transaction.outputs.length;
 
 
 /** Right way **/
-var index1prefix = new Buffer('11');
-var index2prefix = new Buffer('12');
+var index1prefix = new Buffer('11', 'hex');
+var index2prefix = new Buffer('12', 'hex');
 
 var index1key = Buffer.concat([index1prefix, new Buffer(transaction.id)]);
 var index1value = transaction.inputs.length;

--- a/docs/services/db.md
+++ b/docs/services/db.md
@@ -23,7 +23,7 @@ CustomService.prototype.blockHandler = function(block, add, callback) {
 };
 ```
 
-Take a look at the Address Service implementation for more details about how to encode the key, value for the best effeciency and ways to format the keys for streaming reads.
+Take a look at the Address Service implementation for more details about how to encode the key, value for the best efficiency and ways to format the keys for streaming reads.
 
 Additionally the mempool can have an index, the mempool index will be updated once bitcoind and the db have both fully synced. A service can implement a `resetMempoolIndex` method that will be run during this time, and the "synced" event will wait until this task has been finished:
 


### PR DESCRIPTION
Includes examples for programatic use of services as well as using indexes within services.

Edit: Reminder here that this documentation assumes that db prefixes will be global, if this changes the docs will need to be updated to reflect this.