### PR TITLE
Checking for missing headers

### DIFF
--- a/bin/variables.sh
+++ b/bin/variables.sh
@@ -13,7 +13,7 @@ host="${arch}"-"${platform}"
 mac_response=
 check_mac_build_system () {
   if [ "${platform}" == "darwin" ]; then
-    if [ ! -d "/usr/include" ]; then
+    if [ ! -e "/usr/include/stdlib.h" ]; then
       if hash xcode-select 2>/dev/null; then
         mac_response="Please run 'xcode-select --install' from the command line because it seems that you've got Xcode, but not the Xcode command line tools that are required for compiling this project from source..."
       else


### PR DESCRIPTION
closes #346 
Rationale:

- On OS X, a user can have /usr/include, but still not have the standard headers
- this could be because the user uninstalled packages but the /usr/include directory was left behind. 
- by checking for at least stdlib.h, we stand a good chance at finding an issue much easlier