### PR TITLE
Optimized address service mempool index size

### DIFF
--- a/docs/services/bitcoind.md
+++ b/docs/services/bitcoind.md
@@ -101,7 +101,11 @@ node.services.bitcoind.on('tip', function(blockHash) {
 });
 
 node.services.bitcoind.on('tx', function(txInfo) {
-  // a new transaction has been broadcast in the network
+  // a new transaction has entered the mempool
+});
+
+node.services.bitcoind.on('txleave', function(txInfo) {
+  // a new transaction has left the mempool
 });
 ```
 
@@ -110,7 +114,7 @@ The `txInfo` object will have the format:
 ```js
 {
   buffer: <Buffer...>,
-  mempool: true,
+  mempool: true, // will currently always be true
   hash: '7426c707d0e9705bdd8158e60983e37d0f5d63529086d6672b07d9238d5aa623'
 }
 ```

--- a/docs/services/bitcoind.md
+++ b/docs/services/bitcoind.md
@@ -104,7 +104,7 @@ node.services.bitcoind.on('tx', function(txInfo) {
   // a new transaction has entered the mempool
 });
 
-node.services.bitcoind.on('txleave', function(txInfo) {
+node.services.bitcoind.on('txleave', function(txLeaveInfo) {
   // a new transaction has left the mempool
 });
 ```
@@ -115,6 +115,15 @@ The `txInfo` object will have the format:
 {
   buffer: <Buffer...>,
   mempool: true, // will currently always be true
+  hash: '7426c707d0e9705bdd8158e60983e37d0f5d63529086d6672b07d9238d5aa623'
+}
+```
+
+The `txLeaveInfo` object will have the format:
+
+```js
+{
+  buffer: <Buffer...>,
   hash: '7426c707d0e9705bdd8158e60983e37d0f5d63529086d6672b07d9238d5aa623'
 }
 ```

--- a/docs/services/db.md
+++ b/docs/services/db.md
@@ -19,16 +19,6 @@ CustomService.prototype.blockHandler = function(block, add, callback) {
 
 Take a look at the Address Service implementation for more details about how to encode the key, value for the best efficiency and ways to format the keys for streaming reads.
 
-Additionally the mempool can have an index, the mempool index will be updated once bitcoind and the db have both fully synced. A service can implement a `resetMempoolIndex` method that will be run during this time, and the "synced" event will wait until this task has been finished:
-
-```js
-CustomService.prototype.resetMempoolIndex = function(callback) {
-  var transactionBuffers = this.node.services.bitcoind.getMempoolTransactions();
-  // interact over the transactions asynchronously here
-  callback();
-};
-```
-
 ## API Documentation
 These methods are exposed over the JSON-RPC interface and can be called directly from a node via:
 

--- a/etc/bitcoin.patch
+++ b/etc/bitcoin.patch
@@ -367,14 +367,27 @@ index f94771a..72ee00e 100644
 
 
 diff --git a/src/net.h b/src/net.h
-index 17502b9..e181d68 100644
+index 17502b9..c9ae1b2 100644
 --- a/src/net.h
 +++ b/src/net.h
-@@ -99,6 +99,7 @@ struct CNodeSignals
+@@ -99,6 +99,8 @@ struct CNodeSignals
  {
      boost::signals2::signal<int ()> GetHeight;
      boost::signals2::signal<bool (CNode*), CombinerAll> ProcessMessages;
 +    boost::signals2::signal<bool (const CTransaction&)> TxToMemPool;
++    boost::signals2::signal<bool (const CTransaction&)> TxLeaveMemPool;
      boost::signals2::signal<bool (CNode*, bool), CombinerAll> SendMessages;
      boost::signals2::signal<void (NodeId, const CNode*)> InitializeNode;
      boost::signals2::signal<void (NodeId)> FinalizeNode;
+diff --git a/src/txmempool.cpp b/src/txmempool.cpp
+index c3d1b60..03e265d 100644
+--- a/src/txmempool.cpp
++++ b/src/txmempool.cpp
+@@ -133,6 +133,7 @@ void CTxMemPool::remove(const CTransaction &origTx, std::list<CTransaction>& rem
+             if (!mapTx.count(hash))
+                 continue;
+             const CTransaction& tx = mapTx[hash].GetTx();
++            GetNodeSignals().TxLeaveMemPool(tx);
+             if (fRecursive) {
+                 for (unsigned int i = 0; i < tx.vout.size(); i++) {
+                     std::map<COutPoint, CInPoint>::iterator it = mapNextTx.find(COutPoint(hash, i));

--- a/integration/regtest-node.js
+++ b/integration/regtest-node.js
@@ -726,12 +726,15 @@ describe('Node Functionality', function() {
         node.services.bitcoind.sendTransaction(tx.serialize());
 
         setImmediate(function() {
-          var length = node.services.address.mempoolOutputIndex[address].length;
-          length.should.equal(1);
-          should.exist(node.services.address.mempoolOutputIndex[address]);
-          done();
+          var hashBuffer = bitcore.Address(address).hashBuffer;
+          node.services.address._getOutputsMempool(address, hashBuffer, function(err, outs) {
+            if (err) {
+              throw err;
+            }
+            outs.length.should.equal(1);
+            done();
+          });
         });
-
       });
 
     });

--- a/integration/regtest.js
+++ b/integration/regtest.js
@@ -360,6 +360,30 @@ describe('Daemon Binding Functionality', function() {
     });
   });
 
+  describe('transactions leaving the mempool', function() {
+    it('receive event when transaction leaves', function(done) {
+
+      // add transaction to build a new block
+      var tx = bitcore.Transaction();
+      tx.from(utxos[4]);
+      tx.change(privateKey.toAddress());
+      tx.to(destKey.toAddress(), utxos[4].amount * 1e8 - 1000);
+      tx.sign(bitcore.PrivateKey.fromWIF(utxos[4].privateKeyWIF));
+      bitcoind.sendTransaction(tx.serialize());
+
+      bitcoind.once('txleave', function(txInfo) {
+        txInfo.hash.should.equal(tx.hash);
+        done();
+      });
+
+      client.generate(1, function(err, response) {
+        if (err) {
+          throw err;
+        }
+      });
+    });
+  });
+
   describe('mempool functionality', function() {
 
     var fromAddress = 'mszYqVnqKoQx4jcTdJXxwKAissE3Jbrrc1';

--- a/lib/services/address/index.js
+++ b/lib/services/address/index.js
@@ -223,8 +223,10 @@ AddressService.prototype.transactionLeaveHandler = function(txInfo) {
  * @param {Buffer} txInfo.buffer - The transaction buffer
  * @param {Boolean} txInfo.mempool - If the transaction was accepted in the mempool
  * @param {String} txInfo.hash - The hash of the transaction
+ * @param {Function} [callback] - Optional callback
  */
-AddressService.prototype.transactionHandler = function(txInfo) {
+AddressService.prototype.transactionHandler = function(txInfo, callback) {
+  var self = this;
 
   // Basic transaction format is handled by the daemon
   // and we can safely assume the buffer is properly formatted.
@@ -237,15 +239,31 @@ AddressService.prototype.transactionHandler = function(txInfo) {
     this.transactionOutputHandler(messages, tx, i, !txInfo.mempool);
   }
 
-  // Update mempool index
-  if (txInfo.mempool) {
-    this.updateMempoolIndex(tx, true);
+  if (!callback) {
+    callback = function(err) {
+      if (err) {
+        return log.error(err);
+      }
+    };
   }
 
-  for (var key in messages) {
-    this.transactionEventHandler(messages[key]);
-    this.balanceEventHandler(null, messages[key].addressInfo);
+  function finish(err) {
+    if (err) {
+      return callback(err);
+    }
+    for (var key in messages) {
+      self.transactionEventHandler(messages[key]);
+      self.balanceEventHandler(null, messages[key].addressInfo);
+    }
+    callback();
   }
+
+  if (txInfo.mempool) {
+    self.updateMempoolIndex(tx, true, finish);
+  } else {
+    setImmediate(finish);
+  }
+
 };
 
 /**
@@ -254,7 +272,7 @@ AddressService.prototype.transactionHandler = function(txInfo) {
  * @param {Transaction} - An instance of a Bitcore Transaction
  * @param {Boolean} - Add/remove from the index
  */
-AddressService.prototype.updateMempoolIndex = function(tx, add) {
+AddressService.prototype.updateMempoolIndex = function(tx, add, callback) {
   /* jshint maxstatements: 100 */
 
   var operations = [];
@@ -362,11 +380,15 @@ AddressService.prototype.updateMempoolIndex = function(tx, add) {
 
   }
 
-  this.mempoolIndex.batch(operations, function(err) {
-    if (err) {
-      return log.error(err);
-    }
-  });
+  if (!callback) {
+    callback = function(err) {
+      if (err) {
+        return log.error(err);
+      }
+    };
+  }
+
+  this.mempoolIndex.batch(operations, callback);
 
 };
 

--- a/lib/services/address/index.js
+++ b/lib/services/address/index.js
@@ -6,7 +6,6 @@ var async = require('async');
 var index = require('../../');
 var log = index.log;
 var errors = index.errors;
-var Transaction = require('../../transaction');
 var bitcore = require('bitcore-lib');
 var levelup = require('levelup');
 var $ = bitcore.util.preconditions;
@@ -35,6 +34,7 @@ var AddressService = function(options) {
   this.subscriptions['address/balance'] = {};
 
   this.node.services.bitcoind.on('tx', this.transactionHandler.bind(this));
+  this.node.services.bitcoind.on('txleave', this.transactionLeaveHandler.bind(this));
 
   this.mempoolOutputIndex = {};
   this.mempoolInputIndex = {};
@@ -132,6 +132,17 @@ AddressService.prototype.transactionOutputHandler = function(messages, tx, outpu
 };
 
 /**
+ * This will handle data from the daemon "txleave" that a transaction has left the mempool.
+ * @param {Object} txInfo - The data from the daemon.on('txleave') event
+ * @param {Buffer} txInfo.buffer - The transaction buffer
+ * @param {String} txInfo.hash - The hash of the transaction
+ */
+AddressService.prototype.transactionLeaveHandler = function(txInfo) {
+  var tx = bitcore.Transaction().fromBuffer(txInfo.buffer);
+  this.removeMempoolIndex(tx);
+};
+
+/**
  * This will handle data from the daemon "tx" event, go through each of the outputs
  * and send messages by calling `transactionEventHandler` to any subscribers for a
  * particular address.
@@ -161,6 +172,72 @@ AddressService.prototype.transactionHandler = function(txInfo) {
   for (var key in messages) {
     this.transactionEventHandler(messages[key]);
     this.balanceEventHandler(null, messages[key].addressInfo);
+  }
+};
+
+AddressService.prototype.removeMempoolIndex = function(tx) {
+
+  var txid = tx.hash;
+
+  var outputLength = tx.outputs.length;
+  for (var outputIndex = 0; outputIndex < outputLength; outputIndex++) {
+    var output = tx.outputs[outputIndex];
+    if (!output.script) {
+      continue;
+    }
+    var addressInfo = this._extractAddressInfoFromScript(output.script);
+    if (!addressInfo) {
+      continue;
+    }
+
+    var addressStr = bitcore.Address({
+      hashBuffer: addressInfo.hashBuffer,
+      type: addressInfo.addressType,
+      network: this.node.network
+    }).toString();
+
+    // Remove from the mempool output index
+    if (this.mempoolOutputIndex[addressStr]) {
+      var txs = this.mempoolOutputIndex[addressStr];
+      for (var t = 0; t < txs.length; t++) {
+        if (txs[t].txid === txid && txs[t].outputIndex === outputIndex) {
+          txs.splice(t, 1);
+        }
+      }
+      if (txs.length === 0) {
+        delete this.mempoolOutputIndex[addressStr];
+      }
+    }
+  }
+  var inputLength = tx.inputs.length;
+  for (var inputIndex = 0; inputIndex < inputLength; inputIndex++) {
+
+    var input = tx.inputs[inputIndex];
+
+    // Remove from the mempool spent index
+    var spentIndexKey = [input.prevTxId.toString('hex'), input.outputIndex].join('-');
+    if (this.mempoolSpentIndex[spentIndexKey]) {
+      delete this.mempoolSpentIndex[spentIndexKey];
+    }
+
+    var address = input.script.toAddress(this.node.network);
+    if (!address) {
+      continue;
+    }
+    var inputAddressStr = address.toString();
+
+    // Remove from the mempool input index
+    if (this.mempoolInputIndex[inputAddressStr]) {
+      var inputTxs = this.mempoolInputIndex[inputAddressStr];
+      for (var x = 0; x < inputTxs.length; x++) {
+        if (inputTxs[x].txid === txid && inputTxs[x].inputIndex === inputIndex) {
+          inputTxs.splice(x, 1);
+        }
+      }
+      if (inputTxs.length === 0) {
+        delete this.mempoolInputIndex[inputAddressStr];
+      }
+    }
   }
 };
 
@@ -239,40 +316,16 @@ AddressService.prototype.updateMempoolIndex = function(tx) {
     if (!address) {
       continue;
     }
-    var addressStr = address.toString();
-    if (!this.mempoolInputIndex[addressStr]) {
-      this.mempoolInputIndex[addressStr] = [];
+    var inputAddressStr = address.toString();
+    if (!this.mempoolInputIndex[inputAddressStr]) {
+      this.mempoolInputIndex[inputAddressStr] = [];
     }
-    this.mempoolInputIndex[addressStr].push({
+    this.mempoolInputIndex[inputAddressStr].push({
       txid: tx.hash, // TODO use buffer
       inputIndex: inputIndex
     });
   }
 
-};
-
-/**
- * This function is called by the Database Service when the database itself
- * has finished synchronization. It will retrieve a copy of all transactions
- * from the mempool and create an address index for fast look-ups. The previous
- * index will be reset.
- */
-AddressService.prototype.resetMempoolIndex = function(callback) {
-  var self = this;
-  var transactionBuffers = self.node.services.bitcoind.getMempoolTransactions();
-  this.mempoolInputIndex = {};
-  this.mempoolOutputIndex = {};
-  this.mempoolSpentIndex = {};
-  async.each(transactionBuffers, function(txBuffer, next) {
-    var tx = Transaction().fromBuffer(txBuffer);
-    self.updateMempoolIndex(tx);
-    setImmediate(next);
-  }, function(err) {
-    if (err) {
-      return callback(err);
-    }
-    callback();
-  });
 };
 
 /**

--- a/lib/services/address/index.js
+++ b/lib/services/address/index.js
@@ -1,13 +1,18 @@
 'use strict';
 
+var fs = require('fs');
 var BaseService = require('../../service');
 var inherits = require('util').inherits;
 var async = require('async');
+var mkdirp = require('mkdirp');
 var index = require('../../');
 var log = index.log;
 var errors = index.errors;
 var bitcore = require('bitcore-lib');
+var Networks = bitcore.Networks;
 var levelup = require('levelup');
+var leveldown = require('leveldown');
+var memdown = require('memdown');
 var $ = bitcore.util.preconditions;
 var _ = bitcore.deps._;
 var Hash = bitcore.crypto.Hash;
@@ -36,10 +41,14 @@ var AddressService = function(options) {
   this.node.services.bitcoind.on('tx', this.transactionHandler.bind(this));
   this.node.services.bitcoind.on('txleave', this.transactionLeaveHandler.bind(this));
 
-  this.mempoolOutputIndex = {};
-  this.mempoolInputIndex = {};
-  this.mempoolSpentIndex = {};
-
+  this._setMempoolIndexPath();
+  if (options.mempoolMemoryIndex) {
+    this.levelupStore = memdown;
+  } else {
+    this.levelupStore = leveldown;
+  }
+  this.mempoolIndex = null; // Used for larger mempool indexes
+  this.mempoolSpentIndex = {}; // Used for small quick synchronous lookups
 };
 
 inherits(AddressService, BaseService);
@@ -55,8 +64,72 @@ AddressService.PREFIXES = {
   SPENTSMAP: new Buffer('05', 'hex') // Get the input that spends an output
 };
 
+AddressService.MEMPREFIXES = {
+  OUTPUTS: new Buffer('01', 'hex'), // Query mempool outputs by address
+  SPENTS: new Buffer('02', 'hex'), // Query mempool inputs by address
+  SPENTSMAP: new Buffer('03', 'hex') // Query mempool for the input that spends an output
+};
+
 AddressService.SPACER_MIN = new Buffer('00', 'hex');
 AddressService.SPACER_MAX = new Buffer('ff', 'hex');
+
+AddressService.prototype.start = function(callback) {
+  var self = this;
+
+  async.series([
+    function(next) {
+      // Flush any existing mempool index
+      if (fs.existsSync(self.mempoolIndexPath)) {
+        leveldown.destroy(self.mempoolIndexPath, next);
+      } else {
+        setImmediate(next);
+      }
+    },
+    function(next) {
+      if (!fs.existsSync(self.mempoolIndexPath)) {
+        mkdirp(self.mempoolIndexPath, next);
+      } else {
+        setImmediate(next);
+      }
+    },
+    function(next) {
+      self.mempoolIndex = levelup(
+        self.mempoolIndexPath,
+        {
+          db: self.levelupStore,
+          keyEncoding: 'binary',
+          valueEncoding: 'binary',
+          fillCache: false
+        },
+        next
+      );
+    }
+  ], callback);
+
+};
+
+AddressService.prototype.stop = function(callback) {
+  // TODO Keep track of ongoing db requests before shutting down
+  this.mempoolIndex.close(callback);
+};
+
+/**
+ * This function will set `this.dataPath` based on `this.node.network`.
+ * @private
+ */
+AddressService.prototype._setMempoolIndexPath = function() {
+  $.checkState(this.node.datadir, 'Node is expected to have a "datadir" property');
+  var regtest = Networks.get('regtest');
+  if (this.node.network === Networks.livenet) {
+    this.mempoolIndexPath = this.node.datadir + '/bitcore-addressmempool.db';
+  } else if (this.node.network === Networks.testnet) {
+    this.mempoolIndexPath = this.node.datadir + '/testnet3/bitcore-addressmempool.db';
+  } else if (this.node.network === regtest) {
+    this.mempoolIndexPath = this.node.datadir + '/regtest/bitcore-addressmempool.db';
+  } else {
+    throw new Error('Unknown network: ' + this.network);
+  }
+};
 
 /**
  * Called by the Node to get the available API methods for this service,
@@ -139,7 +212,7 @@ AddressService.prototype.transactionOutputHandler = function(messages, tx, outpu
  */
 AddressService.prototype.transactionLeaveHandler = function(txInfo) {
   var tx = bitcore.Transaction().fromBuffer(txInfo.buffer);
-  this.removeMempoolIndex(tx);
+  this.updateMempoolIndex(tx, false);
 };
 
 /**
@@ -166,7 +239,7 @@ AddressService.prototype.transactionHandler = function(txInfo) {
 
   // Update mempool index
   if (txInfo.mempool) {
-    this.updateMempoolIndex(tx);
+    this.updateMempoolIndex(tx, true);
   }
 
   for (var key in messages) {
@@ -175,94 +248,21 @@ AddressService.prototype.transactionHandler = function(txInfo) {
   }
 };
 
-AddressService.prototype.removeMempoolIndex = function(tx) {
-
-  var txid = tx.hash;
-
-  var outputLength = tx.outputs.length;
-  for (var outputIndex = 0; outputIndex < outputLength; outputIndex++) {
-    var output = tx.outputs[outputIndex];
-    if (!output.script) {
-      continue;
-    }
-    var addressInfo = this._extractAddressInfoFromScript(output.script);
-    if (!addressInfo) {
-      continue;
-    }
-
-    var addressStr = bitcore.Address({
-      hashBuffer: addressInfo.hashBuffer,
-      type: addressInfo.addressType,
-      network: this.node.network
-    }).toString();
-
-    // Remove from the mempool output index
-    if (this.mempoolOutputIndex[addressStr]) {
-      var txs = this.mempoolOutputIndex[addressStr];
-      for (var t = 0; t < txs.length; t++) {
-        if (txs[t].txid === txid && txs[t].outputIndex === outputIndex) {
-          txs.splice(t, 1);
-        }
-      }
-      if (txs.length === 0) {
-        delete this.mempoolOutputIndex[addressStr];
-      }
-    }
-  }
-  var inputLength = tx.inputs.length;
-  for (var inputIndex = 0; inputIndex < inputLength; inputIndex++) {
-
-    var input = tx.inputs[inputIndex];
-
-    // Remove from the mempool spent index
-    var spentIndexKey = [input.prevTxId.toString('hex'), input.outputIndex].join('-');
-    if (this.mempoolSpentIndex[spentIndexKey]) {
-      delete this.mempoolSpentIndex[spentIndexKey];
-    }
-
-    var address = input.script.toAddress(this.node.network);
-    if (!address) {
-      continue;
-    }
-    var inputAddressStr = address.toString();
-
-    // Remove from the mempool input index
-    if (this.mempoolInputIndex[inputAddressStr]) {
-      var inputTxs = this.mempoolInputIndex[inputAddressStr];
-      for (var x = 0; x < inputTxs.length; x++) {
-        if (inputTxs[x].txid === txid && inputTxs[x].inputIndex === inputIndex) {
-          inputTxs.splice(x, 1);
-        }
-      }
-      if (inputTxs.length === 0) {
-        delete this.mempoolInputIndex[inputAddressStr];
-      }
-    }
-  }
-};
-
 /**
  * This function will update the mempool address index with the necessary
- * information for further lookups. There are three indexes:
- *
- * mempoolOutputIndex, an object keyed by base58check encoded addresses with values:
- *   txid - A hex string of the transaction hash
- *   outputIndex - A number of the corresponding output
- *   satoshis - Total number of satoshis
- *   script - The script as a hex string
- *
- * mempoolInputIndex, an object keyed by base58check encoded addresses with values:
- *   txid - A hex string of the transaction hash
- *   inputIndex - A number of the corresponding input
- *
- * mempoolSpentIndex, an object keyed by <prevTxId>-<outputIndex> with (buffer) values:
- *   inputTxId - A 32 byte buffer of the input txid
- *   inputIndex - 4 bytes stored as UInt32BE
- *
+ * information for further lookups.
  * @param {Transaction} - An instance of a Bitcore Transaction
+ * @param {Boolean} - Add/remove from the index
  */
-AddressService.prototype.updateMempoolIndex = function(tx) {
-  /* jshint maxstatements: 30 */
+AddressService.prototype.updateMempoolIndex = function(tx, add) {
+  /* jshint maxstatements: 100 */
+
+  var operations = [];
+
+  var action = 'put';
+  if (!add) {
+    action = 'del';
+  }
 
   var txid = tx.hash;
   var txidBuffer = new Buffer(txid, 'hex');
@@ -278,21 +278,23 @@ AddressService.prototype.updateMempoolIndex = function(tx) {
       continue;
     }
 
-    var addressStr = bitcore.Address({
-      hashBuffer: addressInfo.hashBuffer,
-      type: addressInfo.addressType,
-      network: this.node.network
-    }).toString();
+    // Update output index
+    var outputIndexBuffer = new Buffer(4);
+    outputIndexBuffer.writeUInt32BE(outputIndex);
 
-    if (!this.mempoolOutputIndex[addressStr]) {
-      this.mempoolOutputIndex[addressStr] = [];
-    }
+    var outKey = Buffer.concat([
+      AddressService.MEMPREFIXES.OUTPUTS,
+      addressInfo.hashBuffer,
+      txidBuffer,
+      outputIndexBuffer
+    ]);
 
-    this.mempoolOutputIndex[addressStr].push({
-      txid: txid,
-      outputIndex: outputIndex,
-      satoshis: output.satoshis,
-      script: output._scriptBuffer.toString('hex') //TODO use a buffer
+    var outValue = this._encodeOutputValue(output.satoshis, output._scriptBuffer);
+
+    operations.push({
+      type: action,
+      key: outKey,
+      value: outValue
     });
 
   }
@@ -301,30 +303,70 @@ AddressService.prototype.updateMempoolIndex = function(tx) {
 
     var input = tx.inputs[inputIndex];
 
-    // Update spent index
-    var spentIndexKey = [input.prevTxId.toString('hex'), input.outputIndex].join('-');
+    var inputOutputIndexBuffer = new Buffer(4);
+    inputOutputIndexBuffer.writeUInt32BE(input.outputIndex);
 
+    // Add an additional small spent index for fast synchronous lookups
+    var spentIndexSyncKey = this._encodeSpentIndexSyncKey(
+      input.prevTxId,
+      input.outputIndex
+    );
+    if (add) {
+      this.mempoolSpentIndex[spentIndexSyncKey] = true;
+    } else {
+      delete this.mempoolSpentIndex[spentIndexSyncKey];
+    }
+
+    // Add a more detailed spent index with values
+    var spentIndexKey = Buffer.concat([
+      AddressService.MEMPREFIXES.SPENTSMAP,
+      input.prevTxId,
+      inputOutputIndexBuffer
+    ]);
     var inputIndexBuffer = new Buffer(4);
     inputIndexBuffer.writeUInt32BE(inputIndex);
     var inputIndexValue = Buffer.concat([
       txidBuffer,
       inputIndexBuffer
     ]);
-    this.mempoolSpentIndex[spentIndexKey] = inputIndexValue;
+    operations.push({
+      type: action,
+      key: spentIndexKey,
+      value: inputIndexValue
+    });
 
-    var address = input.script.toAddress(this.node.network);
-    if (!address) {
+    // Update input index
+    var inputHashBuffer;
+    if (input.script.isPublicKeyHashIn()) {
+      inputHashBuffer = Hash.sha256ripemd160(input.script.chunks[1].buf);
+    } else if (input.script.isScriptHashIn()) {
+      inputHashBuffer = Hash.sha256ripemd160(input.script.chunks[input.script.chunks.length - 1].buf);
+    } else {
       continue;
     }
-    var inputAddressStr = address.toString();
-    if (!this.mempoolInputIndex[inputAddressStr]) {
-      this.mempoolInputIndex[inputAddressStr] = [];
-    }
-    this.mempoolInputIndex[inputAddressStr].push({
-      txid: tx.hash, // TODO use buffer
-      inputIndex: inputIndex
+    var inputKey = Buffer.concat([
+      AddressService.MEMPREFIXES.SPENTS,
+      inputHashBuffer,
+      input.prevTxId,
+      inputOutputIndexBuffer
+    ]);
+    var inputValue = Buffer.concat([
+      txidBuffer,
+      inputIndexBuffer
+    ]);
+    operations.push({
+      type: action,
+      key: inputKey,
+      value: inputValue
     });
+
   }
+
+  this.mempoolIndex.batch(operations, function(err) {
+    if (err) {
+      return log.error(err);
+    }
+  });
 
 };
 
@@ -487,6 +529,16 @@ AddressService.prototype.blockHandler = function(block, addOutput, callback) {
   setImmediate(function() {
     callback(null, operations);
   });
+};
+
+AddressService.prototype._encodeSpentIndexSyncKey = function(txidBuffer, outputIndex) {
+  var outputIndexBuffer = new Buffer(4);
+  outputIndexBuffer.writeUInt32BE(outputIndex);
+  var key = Buffer.concat([
+    txidBuffer,
+    outputIndexBuffer
+  ]);
+  return key.toString('binary');
 };
 
 AddressService.prototype._encodeOutputKey = function(hashBuffer, height, txidBuffer, outputIndex) {
@@ -801,15 +853,9 @@ AddressService.prototype.getInputForOutput = function(txid, outputIndex, options
     txidBuffer = new Buffer(txid, 'hex');
   }
   if (options.queryMempool) {
-    var spentIndexKey = [txid.toString('hex'), outputIndex].join('-');
-    if (this.mempoolSpentIndex[spentIndexKey]) {
-      var mempoolValue = this.mempoolSpentIndex[spentIndexKey];
-      var inputTxId = mempoolValue.slice(0, 32);
-      var inputIndex = mempoolValue.readUInt32BE(32);
-      return callback(null, {
-        inputTxId: inputTxId.toString('hex'),
-        inputIndex: inputIndex
-      });
+    var spentIndexSyncKey = this._encodeSpentIndexSyncKey(txidBuffer, outputIndex);
+    if (this.mempoolSpentIndex[spentIndexSyncKey]) {
+      return this._getSpentMempool(txidBuffer, outputIndex, callback);
     }
   }
   var key = this._encodeInputKeyMap(txidBuffer, outputIndex);
@@ -920,24 +966,95 @@ AddressService.prototype.getInputs = function(addressStr, options, callback) {
     }
 
     if(options.queryMempool) {
-      var mempoolInputs = self.mempoolInputIndex[addressStr];
-      if (mempoolInputs) {
-        for(var i = 0; i < mempoolInputs.length; i++) {
-          var newInput = _.clone(mempoolInputs[i]);
-          newInput.address = addressStr;
-          newInput.height = -1;
-          newInput.confirmations = 0;
-          inputs.push(newInput);
+      self._getInputsMempool(addressStr, hashBuffer, function(err, mempoolInputs) {
+        if (err) {
+          return callback(err);
         }
-      }
+        inputs = inputs.concat(mempoolInputs);
+        callback(null, inputs);
+      });
+    } else {
+      callback(null, inputs);
     }
-
-    callback(null, inputs);
 
   });
 
   return stream;
 
+};
+
+AddressService.prototype._getInputsMempool = function(addressStr, hashBuffer, callback) {
+  var self = this;
+  var mempoolInputs = [];
+
+  var stream = self.mempoolIndex.createReadStream({
+    gte: Buffer.concat([
+      AddressService.MEMPREFIXES.SPENTS,
+      hashBuffer,
+      AddressService.SPACER_MIN
+    ]),
+    lte: Buffer.concat([
+      AddressService.MEMPREFIXES.SPENTS,
+      hashBuffer,
+      AddressService.SPACER_MAX
+    ]),
+    valueEncoding: 'binary',
+    keyEncoding: 'binary'
+  });
+
+  stream.on('data', function(data) {
+    var txid = data.value.slice(0, 32);
+    var inputIndex = data.value.readUInt32BE(32);
+    var output = {
+      address: addressStr,
+      txid: txid.toString('hex'), //TODO use a buffer
+      inputIndex: inputIndex,
+      height: -1,
+      confirmations: 0
+    };
+    mempoolInputs.push(output);
+  });
+
+  var error;
+
+  stream.on('error', function(streamError) {
+    if (streamError) {
+      error = streamError;
+    }
+  });
+
+  stream.on('close', function() {
+    if (error) {
+      return callback(error);
+    }
+    callback(null, mempoolInputs);
+  });
+
+};
+
+AddressService.prototype._getSpentMempool = function(txidBuffer, outputIndex, callback) {
+  var outputIndexBuffer = new Buffer(4);
+  outputIndexBuffer.writeUInt32BE(outputIndex);
+  var spentIndexKey = Buffer.concat([
+    AddressService.MEMPREFIXES.SPENTSMAP,
+    txidBuffer,
+    outputIndexBuffer
+  ]);
+
+  this.mempoolIndex.get(
+    spentIndexKey,
+    function(err, mempoolValue) {
+      if (err) {
+        return callback(err);
+      }
+      var inputTxId = mempoolValue.slice(0, 32);
+      var inputIndex = mempoolValue.readUInt32BE(32);
+      callback(null, {
+        inputTxId: inputTxId.toString('hex'),
+        inputIndex: inputIndex
+      });
+    }
+  );
 };
 
 /**
@@ -1033,21 +1150,72 @@ AddressService.prototype.getOutputs = function(addressStr, options, callback) {
     }
 
     if(options.queryMempool) {
-      var mempoolOutputs = self.mempoolOutputIndex[addressStr];
-      if (mempoolOutputs) {
-        for(var i = 0; i < mempoolOutputs.length; i++) {
-          var newOutput = _.clone(mempoolOutputs[i]);
-          newOutput.address = addressStr;
-          newOutput.height = -1;
-          newOutput.confirmations = 0;
-          outputs.push(newOutput);
+      self._getOutputsMempool(addressStr, hashBuffer, function(err, mempoolOutputs) {
+        if (err) {
+          return callback(err);
         }
-      }
+        outputs = outputs.concat(mempoolOutputs);
+        callback(null, outputs);
+      });
+    } else {
+      callback(null, outputs);
     }
-    callback(null, outputs);
   });
 
   return stream;
+
+};
+
+AddressService.prototype._getOutputsMempool = function(addressStr, hashBuffer, callback) {
+  var self = this;
+  var mempoolOutputs = [];
+
+  var stream = self.mempoolIndex.createReadStream({
+    gte: Buffer.concat([
+      AddressService.MEMPREFIXES.OUTPUTS,
+      hashBuffer,
+      AddressService.SPACER_MIN
+    ]),
+    lte: Buffer.concat([
+      AddressService.MEMPREFIXES.OUTPUTS,
+      hashBuffer,
+      AddressService.SPACER_MAX
+    ]),
+    valueEncoding: 'binary',
+    keyEncoding: 'binary'
+  });
+
+  stream.on('data', function(data) {
+    // Format of data: prefix: 1, hashBuffer: 20, txid: 32, outputIndex: 4
+    var txid = data.key.slice(21, 53);
+    var outputIndex = data.key.readUInt32BE(53);
+    var value = self._decodeOutputValue(data.value);
+    var output = {
+      address: addressStr,
+      txid: txid.toString('hex'), //TODO use a buffer
+      outputIndex: outputIndex,
+      height: -1,
+      satoshis: value.satoshis,
+      script: value.scriptBuffer.toString('hex'), //TODO use a buffer
+      confirmations: 0
+    };
+    mempoolOutputs.push(output);
+  });
+
+  var error;
+
+  stream.on('error', function(streamError) {
+    if (streamError) {
+      error = streamError;
+    }
+  });
+
+  stream.on('close', function() {
+    if (error) {
+      return callback(error);
+    }
+    callback(null, mempoolOutputs);
+  });
 
 };
 
@@ -1141,14 +1309,15 @@ AddressService.prototype.isSpent = function(output, options, callback) {
   var txid = output.prevTxId ? output.prevTxId.toString('hex') : output.txid;
   var spent = self.node.services.bitcoind.isSpent(txid, output.outputIndex);
   if (!spent && queryMempool) {
-    var spentIndexKey = [txid, output.outputIndex].join('-');
-    spent = self.mempoolSpentIndex[spentIndexKey] ? true : false;
+    var spentIndexSyncKey = this._encodeSpentIndexSyncKey(output.prevTxId, output.outputIndex);
+    spent = self.mempoolSpentIndex[spentIndexSyncKey] ? true : false;
   }
   setImmediate(function() {
     // TODO error should be the first argument?
     callback(spent);
   });
 };
+
 
 /**
  * This will give the history for many addresses limited by a range of block heights (to limit
@@ -1248,8 +1417,11 @@ AddressService.prototype.getAddressSummary = function(address, options, callback
       for(var i = 0; i < outputs.length; i++) {
         // Bitcoind's isSpent only works for confirmed transactions
         var spentDB = self.node.services.bitcoind.isSpent(outputs[i].txid, outputs[i].outputIndex);
-        var spentIndexKey = [outputs[i].txid, outputs[i].outputIndex].join('-');
-        var spentMempool = self.mempoolSpentIndex[spentIndexKey];
+        var spentIndexSyncKey = self._encodeSpentIndexSyncKey(
+          new Buffer(outputs[i].txid, 'hex'), // TODO: get buffer directly
+          outputs[i].outputIndex
+        );
+        var spentMempool = self.mempoolSpentIndex[spentIndexSyncKey];
 
         txids.push(outputs[i]);
 

--- a/lib/services/address/index.js
+++ b/lib/services/address/index.js
@@ -1309,7 +1309,8 @@ AddressService.prototype.isSpent = function(output, options, callback) {
   var txid = output.prevTxId ? output.prevTxId.toString('hex') : output.txid;
   var spent = self.node.services.bitcoind.isSpent(txid, output.outputIndex);
   if (!spent && queryMempool) {
-    var spentIndexSyncKey = this._encodeSpentIndexSyncKey(output.prevTxId, output.outputIndex);
+    var txidBuffer = new Buffer(txid, 'hex');
+    var spentIndexSyncKey = this._encodeSpentIndexSyncKey(txidBuffer, output.outputIndex);
     spent = self.mempoolSpentIndex[spentIndexSyncKey] ? true : false;
   }
   setImmediate(function() {

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -110,10 +110,17 @@ Bitcoin.prototype._registerEventHandlers = function() {
   // Set the height and emit a new tip
   bindings.onTipUpdate(self._onTipUpdate.bind(this));
 
-  // Register callback function to handle incoming transactions
+  // Register callback function to handle transactions entering the mempool
   bindings.startTxMon(function(txs) {
     for(var i = 0; i < txs.length; i++) {
       self.emit('tx', txs[i]);
+    }
+  });
+
+  // Register callback function to handle transactions leaving the mempool
+  bindings.startTxMonLeave(function(txs) {
+    for(var i = 0; i < txs.length; i++) {
+      self.emit('txleave', txs[i]);
     }
   });
 };

--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -455,24 +455,6 @@ DB.prototype.disconnectBlock = function(block, callback) {
 };
 
 /**
- * Will run all `resetMempoolIndex` methods implemented on sibling
- * services to update the mempool indexes.
- */
-DB.prototype.runAllMempoolIndexes = function(callback) {
-  async.eachSeries(
-    this.node.services,
-    function(service, next) {
-      if (service.resetMempoolIndex) {
-        service.resetMempoolIndex(next);
-      } else {
-        setImmediate(next);
-      }
-    },
-    callback
-  );
-};
-
-/**
  * Will collect all database operations for a block from other services that implement
  * `blockHandler` methods and then save operations to the database.
  * @param {Block} block - The bitcore block
@@ -745,15 +727,8 @@ DB.prototype.sync = function() {
     }
 
     if (self.node.services.bitcoind.isSynced()) {
-      self.runAllMempoolIndexes(function(err) {
-        if (err) {
-          Error.captureStackTrace(err);
-          return self.node.emit('error', err);
-        }
-
-        self.bitcoindSyncing = false;
-        self.node.emit('synced');
-      });
+      self.bitcoindSyncing = false;
+      self.node.emit('synced');
     } else {
       self.bitcoindSyncing = false;
     }

--- a/test/services/address/index.unit.js
+++ b/test/services/address/index.unit.js
@@ -1545,16 +1545,47 @@ describe('Address Service', function() {
         }
       }
     };
-    it('should give true if bitcoind.isSpent gives true', function(done) {
+    it('should give true if bitcoind.isSpent gives true (with output info)', function(done) {
       var am = new AddressService({
         mempoolMemoryIndex: true,
         node: testnode
       });
+      var isSpent = sinon.stub().returns(true);
       am.node.services.bitcoind = {
-        isSpent: sinon.stub().returns(true),
+        isSpent: isSpent,
         on: sinon.stub()
       };
-      am.isSpent({}, {}, function(spent) {
+      var output = {
+        txid: '4228d3f41051f914f71a1dcbbe4098e29a07cc2672fdadab0763d88ffd6ffa57',
+        outputIndex: 3
+      };
+      am.isSpent(output, {}, function(spent) {
+        isSpent.callCount.should.equal(1);
+        isSpent.args[0][0].should.equal(output.txid);
+        isSpent.args[0][1].should.equal(output.outputIndex);
+        spent.should.equal(true);
+        done();
+      });
+    });
+    it('should give true if bitcoind.isSpent gives true (with input)', function(done) {
+      var am = new AddressService({
+        mempoolMemoryIndex: true,
+        node: testnode
+      });
+      var isSpent = sinon.stub().returns(true);
+      am.node.services.bitcoind = {
+        isSpent: isSpent,
+        on: sinon.stub()
+      };
+      var txid = '4228d3f41051f914f71a1dcbbe4098e29a07cc2672fdadab0763d88ffd6ffa57';
+      var output = {
+        prevTxId: new Buffer(txid, 'hex'),
+        outputIndex: 4
+      };
+      am.isSpent(output, {}, function(spent) {
+        isSpent.callCount.should.equal(1);
+        isSpent.args[0][0].should.equal(txid);
+        isSpent.args[0][1].should.equal(output.outputIndex);
         spent.should.equal(true);
         done();
       });

--- a/test/services/address/index.unit.js
+++ b/test/services/address/index.unit.js
@@ -357,24 +357,30 @@ describe('Address Service', function() {
   });
 
   describe('#transactionHandler', function() {
-    it('will pass outputs to transactionOutputHandler and call transactionEventHandler and balanceEventHandler', function() {
+    it('will pass outputs to transactionOutputHandler and call transactionEventHandler and balanceEventHandler', function(done) {
       var txBuf = new Buffer('01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000', 'hex');
-      var am = new AddressService({
+      var am1 = new AddressService({
         mempoolMemoryIndex: true,
         node: mocknode
       });
       var address = '12c6DSiU4Rq3P4ZxziKxzrL5LmMBrzjrJX';
       var message = {};
-      am.transactionOutputHandler = function(messages) {
+      am1.transactionOutputHandler = function(messages) {
         messages[address] = message;
       };
-      am.transactionEventHandler = sinon.spy();
-      am.balanceEventHandler = sinon.spy();
-      am.transactionHandler({
+      am1.transactionEventHandler = sinon.stub();
+      am1.balanceEventHandler = sinon.stub();
+      am1.transactionHandler({
         buffer: txBuf
+      }, function(err) {
+        if (err) {
+          throw err;
+        }
+        am1.transactionEventHandler.callCount.should.equal(1);
+        am1.balanceEventHandler.callCount.should.equal(1);
+        done();
       });
-      am.transactionEventHandler.callCount.should.equal(1);
-      am.balanceEventHandler.callCount.should.equal(1);
+
     });
   });
 

--- a/test/services/address/index.unit.js
+++ b/test/services/address/index.unit.js
@@ -1036,9 +1036,8 @@ describe('Address Service', function() {
       });
     });
   });
-  describe('#updateMempoolIndex', function() {
+  describe('#updateMempoolIndex/#removeMempoolIndex', function() {
     var am;
-    var db = {};
     var tx = Transaction().fromBuffer(txBuf);
 
     before(function() {
@@ -1049,35 +1048,20 @@ describe('Address Service', function() {
       am.updateMempoolIndex(tx);
       am.mempoolInputIndex['18Z29uNgWyUDtNyTKE1PaurbSR131EfANc'][0].txid.should.equal('45202ffdeb8344af4dec07cddf0478485dc65cc7d08303e45959630c89b51ea2');
       am.mempoolOutputIndex['12w93weN8oti3P1e5VYEuygqyujhADF7J5'][0].txid.should.equal('45202ffdeb8344af4dec07cddf0478485dc65cc7d08303e45959630c89b51ea2');
+      Object.keys(am.mempoolSpentIndex).length.should.equal(14);
       am.mempoolInputIndex['1JT7KDYwT9JY9o2vyqcKNSJgTWeKfV3ui8'].length.should.equal(12);
       am.mempoolOutputIndex['12w93weN8oti3P1e5VYEuygqyujhADF7J5'].length.should.equal(1);
     });
 
-  });
-  describe('#resetMempoolIndex', function() {
-    var am;
-    var db = {};
-
-    before(function() {
-      var testnode = {
-        db: db,
-        services: {
-          bitcoind: {
-            getMempoolTransactions: sinon.stub().returns([txBuf]),
-            on: sinon.stub()
-          }
-        }
-      };
-      am = new AddressService({node: testnode});
-      am.updateMempoolIndex = sinon.stub();
-
+    it('will remove the input and output indexes', function() {
+      am.removeMempoolIndex(tx);
+      should.not.exist(am.mempoolInputIndex['18Z29uNgWyUDtNyTKE1PaurbSR131EfANc']);
+      should.not.exist(am.mempoolOutputIndex['12w93weN8oti3P1e5VYEuygqyujhADF7J5']);
+      Object.keys(am.mempoolSpentIndex).length.should.equal(0);
+      should.not.exist(am.mempoolInputIndex['1JT7KDYwT9JY9o2vyqcKNSJgTWeKfV3ui8']);
+      should.not.exist(am.mempoolOutputIndex['12w93weN8oti3P1e5VYEuygqyujhADF7J5']);
     });
-    it('will reset the input and output indexes', function(done) {
-      am.resetMempoolIndex(function() {
-        am.updateMempoolIndex.callCount.should.equal(1);
-        done();
-      });
-    });
+
   });
   describe('#getAddressSummary', function() {
     var node = {

--- a/test/services/bitcoind.unit.js
+++ b/test/services/bitcoind.unit.js
@@ -144,7 +144,8 @@ describe('Bitcoin Service', function() {
           name.should.equal('bitcoind.node');
           return {
             onTipUpdate: sinon.stub(),
-            startTxMon: sinon.stub().callsArgWith(0, [transaction])
+            startTxMon: sinon.stub().callsArgWith(0, [transaction]),
+            startTxMonLeave: sinon.stub().callsArgWith(0, [transaction])
           };
         }
       });
@@ -175,7 +176,8 @@ describe('Bitcoin Service', function() {
                 callback(height++);
               });
             },
-            startTxMon: sinon.stub()
+            startTxMon: sinon.stub(),
+            startTxMonLeave: sinon.stub()
           };
         }
       });

--- a/test/services/db.unit.js
+++ b/test/services/db.unit.js
@@ -839,7 +839,6 @@ describe('DB Service', function() {
       var blockBuffer = new Buffer(blockData, 'hex');
       var block = Block.fromBuffer(blockBuffer);
       db.node.services = {};
-      db.runAllMempoolIndexes = sinon.stub().callsArg(0);
       db.node.services.bitcoind = {
         getBlock: sinon.stub().callsArgWith(1, null, blockBuffer),
         isSynced: sinon.stub().returns(true),
@@ -858,7 +857,6 @@ describe('DB Service', function() {
         callback();
       };
       db.node.once('synced', function() {
-        db.runAllMempoolIndexes.callCount.should.equal(1);
         done();
       });
       db.sync();


### PR DESCRIPTION
Closes https://github.com/bitpay/bitcore-node/issues/324

New features:
- significant memory footprint improvements
- address service now keeps mempool index with levelup that can be configured to use memdown or leveldown (default)
- the `mempoolSpentIndex` has been kept to be memory only and the key will be 37 bytes
- mempool address index size should be roughly half the size (binary encoding instead of utf-8)
- mempool indexes are more accurately kept in sync by using `tx` and `txleave` events from bitcoind and will nolonger make an expensive query for all transactions in the mempool

Includes breaking API changes:
- address service `resetMempoolIndex` method have been removed
- db service `runAllMempoolIndexes` has been removed
