### PR TITLE
DB: export getBlockIndex and getBestBlockHash

### DIFF
--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -187,6 +187,8 @@ DB.prototype.transactionHandler = function(txInfo) {
 DB.prototype.getAPIMethods = function() {
   var methods = [
     ['getBlock', this, this.getBlock, 1],
+    ['getBlockIndex', this, this.getBlockIndex, 1],
+    ['getBestBlockHash', this, this.getBestBlockHash, 0],
     ['getBlockHashesByTimestamp', this, this.getBlockHashesByTimestamp, 2],
     ['getTransaction', this, this.getTransaction, 2],
     ['getTransactionWithBlockInfo', this, this.getTransactionWithBlockInfo, 2],
@@ -265,6 +267,29 @@ DB.prototype.getBlock = function(hash, callback) {
       return callback(err);
     }
     callback(null, Block.fromBuffer(blockBuffer));
+  });
+};
+
+/**
+ * Will get a hash of the best block from bitcoind
+ */
+DB.prototype.getBestBlockHash = function(callback) {
+  var self = this;
+  setImmediate(function () {
+    var hash = self.node.services.bitcoind.getBestBlockHash();
+    callback(null, hash);
+  });
+};
+
+/**
+ * Will retrieve a block index from bitcoind for a given block hash
+ * @param {String} hash - A block hash
+ */
+DB.prototype.getBlockIndex = function(hash, callback) {
+  var self = this;
+  setImmediate(function () {
+    var index = self.node.services.bitcoind.getBlockIndex(hash);
+    callback(null, index);
   });
 };
 

--- a/test/services/db.unit.js
+++ b/test/services/db.unit.js
@@ -688,7 +688,7 @@ describe('DB Service', function() {
       db.node = {};
       db.node.services = {};
       var methods = db.getAPIMethods();
-      methods.length.should.equal(6);
+      methods.length.should.equal(8);
     });
   });
 


### PR DESCRIPTION
Simply exporting two methods of `bitcoind` service through DB. I needed this for partial transaction history update.