### PR TITLE
Fix #380. Add missing git config properties if required before committing bitcoin core patch.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ addons:
 node_js:
   - "v0.12.7"
   - "v4"
-before_install:
-  - git config --global user.email "dev@bitpay.com"
-  - git config --global user.name "BitPay, Inc."
 script:
   - _mocha -R spec integration/regtest.js
   - _mocha -R spec integration/regtest-node.js

--- a/bin/patch-bitcoin
+++ b/bin/patch-bitcoin
@@ -23,6 +23,13 @@ git checkout -b "libbitcoind-$(date '+%Y.%m.%d')" || exit 1
 patch -p1 < "$patch_file" || exit 1
 
 git add --all || exit 1
+
+[ -n "$( git config user.name )" ] \
+    || git config user.name 'Bitcore Build'
+
+[ -n "$( git config user.email )" ] \
+    || git config user.email "$( id -n -u )@$( hostname -f )"
+
 git commit -a -m 'allow compiling of libbitcoind.so.' || exit 1
 
 echo 'Patch completed successfully.'

--- a/docs/build.md
+++ b/docs/build.md
@@ -6,8 +6,6 @@ If git is not already installed, it can be installed by running:
 
 ```bash
 sudo apt-get install git
-git config --global user.email "you@example.com"
-git config --global user.name "Your Name"
 ```
 
 If Node.js v0.12 isn't installed, it can be installed using "nvm", it can be done by following the installation script at [https://github.com/creationix/nvm#install-script](https://github.com/creationix/nvm#install-script) and then install version v0.12


### PR DESCRIPTION
Fix #380. Add missing git config properties if required before committing bitcoin core patch.

This only adds the missing properties locally if they are not available globally. In other words, this is useful for installing in environments like Docker containers where the installing user typically does not have a global git configuration. That being said, it should not overwrite or change anything (locally or globally) for users with existing global configurations.