### PR TITLE
Fix #381. Fix #382. Update prerequisites. Use wget for fetching remote archives.

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -10,20 +10,10 @@ binary_url="https://${bucket_name}.s3.amazonaws.com/${tarball_name}"
 
 echo "Downloading binary: ${binary_url}"
 
-is_curl=true
-if hash curl 2>/dev/null; then
-  curl --fail -I $binary_url >/dev/null 2>&1
-else
-  is_curl=false
-  wget --server-response --spider $binary_url >/dev/null 2>&1
-fi
+wget --server-response --spider $binary_url >/dev/null 2>&1
 
 if test $? -eq 0; then
-  if [ "${is_curl}" = true ]; then
-    curl $binary_url > $tarball_name
-  else
-    wget $binary_url
-  fi
+  wget $binary_url
   if test -e "${tarball_name}"; then
     echo "Unpacking binary distribution"
     tar -xvzf $tarball_name

--- a/docs/build.md
+++ b/docs/build.md
@@ -16,10 +16,10 @@ If Node.js v0.12 isn't installed, it can be installed using "nvm", it can be don
 nvm install v0.12
 ```
 
-To build Bitcoin Core and bindings development packages are needed:
+To build Bitcoin Core, the following packages are needed:
 
 ```bash
-sudo apt-get install build-essential libtool autotools-dev automake autoconf pkg-config libssl-dev
+sudo apt-get install automake autotools-dev build-essential libssl-dev libtool pkg-config python wget
 ```
 
 Clone the bitcore-node repository locally:


### PR DESCRIPTION
Fix #381. Fix #382. Update prerequisites. Always use `wget` (not `curl`) for fetching remote archives.