### PR TITLE
Added ARM prebuilt binaries for Leveldown

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "commander": "^2.8.1",
     "errno": "^0.1.4",
     "express": "^4.13.3",
-    "leveldown": "^1.4.3",
+    "leveldown": "bitpay/leveldown#bitpay-1.4.4",
     "levelup": "^1.3.1",
     "liftoff": "^2.2.0",
     "memdown": "^1.0.0",


### PR DESCRIPTION
- this is necessary because leveldown does not supply an ARM binary
- butcher needs a binary so that compiler tool chains are not necessary