### PR TITLE
Switch to use enableRegtest from bitcore-lib

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -71,19 +71,7 @@ Node.prototype._setNetwork = function(config) {
   if (config.network === 'testnet') {
     this.network = Networks.get('testnet');
   } else if (config.network === 'regtest') {
-    Networks.remove(Networks.testnet);
-    Networks.add({
-      name: 'regtest',
-      alias: 'regtest',
-      pubkeyhash: 0x6f,
-      privatekey: 0xef,
-      scripthash: 0xc4,
-      xpubkey: 0x043587cf,
-      xprivkey: 0x04358394,
-      networkMagic: 0xfabfb5da,
-      port: 18444,
-      dnsSeeds: [ ]
-    });
+    Networks.enableRegtest();
     this.network = Networks.get('regtest');
   } else {
     this.network = Networks.defaultNetwork;

--- a/lib/services/address/index.js
+++ b/lib/services/address/index.js
@@ -121,13 +121,14 @@ AddressService.prototype._setMempoolIndexPath = function() {
 AddressService.prototype._getDBPathFor = function(dbname) {
   $.checkState(this.node.datadir, 'Node is expected to have a "datadir" property');
   var path;
-  var regtest = Networks.get('regtest');
   if (this.node.network === Networks.livenet) {
     path = this.node.datadir + '/' + dbname;
   } else if (this.node.network === Networks.testnet) {
-    path = this.node.datadir + '/testnet3/' + dbname;
-  } else if (this.node.network === regtest) {
-    path = this.node.datadir + '/regtest/' + dbname;
+    if (this.node.network.regtestEnabled) {
+      path = this.node.datadir + '/regtest/' + dbname;
+    } else {
+      path = this.node.datadir + '/testnet3/' + dbname;
+    }
   } else {
     throw new Error('Unknown network: ' + this.network);
   }

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -154,9 +154,14 @@ Bitcoin.prototype.start = function(callback) {
 
   this._loadConfiguration();
 
+  var networkName = this.node.network.name;
+  if (this.node.network.regtestEnabled) {
+    networkName = 'regtest';
+  }
+
   bindings.start({
     datadir: this.node.datadir,
-    network: this.node.network.name
+    network: networkName
   }, function(err) {
     if(err) {
       return callback(err);

--- a/lib/services/db.js
+++ b/lib/services/db.js
@@ -89,13 +89,14 @@ DB.DEFAULT_MAX_OPEN_FILES = 200;
  */
 DB.prototype._setDataPath = function() {
   $.checkState(this.node.datadir, 'Node is expected to have a "datadir" property');
-  var regtest = Networks.get('regtest');
   if (this.node.network === Networks.livenet) {
     this.dataPath = this.node.datadir + '/bitcore-node.db';
   } else if (this.node.network === Networks.testnet) {
-    this.dataPath = this.node.datadir + '/testnet3/bitcore-node.db';
-  } else if (this.node.network === regtest) {
-    this.dataPath = this.node.datadir + '/regtest/bitcore-node.db';
+    if (this.node.network.regtestEnabled) {
+      this.dataPath = this.node.datadir + '/regtest/bitcore-node.db';
+    } else {
+      this.dataPath = this.node.datadir + '/testnet3/bitcore-node.db';
+    }
   } else {
     throw new Error('Unknown network: ' + this.network);
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "async": "^1.3.0",
     "bindings": "^1.2.1",
-    "bitcore-lib": "bitpay/bitcore-lib#9702105ad9e78977f52df6ce231d87c47742f9be",
+    "bitcore-lib": "^0.13.13",
     "body-parser": "^1.13.3",
     "colors": "^1.1.2",
     "commander": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "async": "^1.3.0",
     "bindings": "^1.2.1",
-    "bitcore-lib": "^0.13.7",
+    "bitcore-lib": "bitpay/bitcore-lib#9702105ad9e78977f52df6ce231d87c47742f9be",
     "body-parser": "^1.13.3",
     "colors": "^1.1.2",
     "commander": "^2.8.1",

--- a/test/node.unit.js
+++ b/test/node.unit.js
@@ -21,29 +21,9 @@ describe('Bitcore Node', function() {
     Node.prototype._loadConfiguration = sinon.spy();
     Node.prototype._initialize = sinon.spy();
   });
+
   after(function() {
-    var regtest = Networks.get('regtest');
-    if (regtest) {
-      Networks.remove(regtest);
-    }
-    // restore testnet
-    Networks.add({
-      name: 'testnet',
-      alias: 'testnet',
-      pubkeyhash: 0x6f,
-      privatekey: 0xef,
-      scripthash: 0xc4,
-      xpubkey: 0x043587cf,
-      xprivkey: 0x04358394,
-      networkMagic: 0x0b110907,
-      port: 18333,
-      dnsSeeds: [
-        'testnet-seed.bitcoin.petertodd.org',
-        'testnet-seed.bluematt.me',
-        'testnet-seed.alexykot.me',
-        'testnet-seed.bitcoin.schildbach.de'
-      ],
-    });
+    Networks.disableRegtest();
   });
 
   describe('@constructor', function() {

--- a/test/services/address/index.unit.js
+++ b/test/services/address/index.unit.js
@@ -271,19 +271,7 @@ describe('Address Service', function() {
     });
     it('should load the db with regtest', function() {
       // Switch to use regtest
-      Networks.remove(Networks.testnet);
-      Networks.add({
-        name: 'regtest',
-        alias: 'regtest',
-        pubkeyhash: 0x6f,
-        privatekey: 0xef,
-        scripthash: 0xc4,
-        xpubkey: 0x043587cf,
-        xprivkey: 0x04358394,
-        networkMagic: 0xfabfb5da,
-        port: 18444,
-        dnsSeeds: [ ]
-      });
+      Networks.enableRegtest();
       var regtest = Networks.get('regtest');
       var testnode = {
         network: regtest,
@@ -299,7 +287,7 @@ describe('Address Service', function() {
         node: testnode
       });
       am.mempoolIndexPath.should.equal(process.env.HOME + '/.bitcoin/regtest/bitcore-addressmempool.db');
-      Networks.remove(regtest);
+      Networks.disableRegtest();
     });
   });
 
@@ -735,6 +723,7 @@ describe('Address Service', function() {
   describe('#createInputsStream', function() {
     it('transform stream from buffer into object', function(done) {
       var testnode = {
+        network: Networks.livenet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -777,6 +766,7 @@ describe('Address Service', function() {
     it('will stream all keys', function() {
       var streamStub = sinon.stub().returns({});
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -808,6 +798,7 @@ describe('Address Service', function() {
     it('will stream keys based on a range of block heights', function() {
       var streamStub = sinon.stub().returns({});
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -1144,6 +1135,7 @@ describe('Address Service', function() {
   describe('#createOutputsStream', function() {
     it('transform stream from buffer into object', function(done) {
       var testnode = {
+        network: Networks.livenet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -1188,6 +1180,7 @@ describe('Address Service', function() {
     it('will stream all keys', function() {
       var streamStub = sinon.stub().returns({});
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -1219,6 +1212,7 @@ describe('Address Service', function() {
     it('will stream keys based on a range of block heights', function() {
       var streamStub = sinon.stub().returns({});
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2030,6 +2024,7 @@ describe('Address Service', function() {
     });
     it('will handle error from _getAddressConfirmedSummary', function(done) {
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2052,6 +2047,7 @@ describe('Address Service', function() {
     });
     it('will handle error from _getAddressMempoolSummary', function(done) {
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2075,6 +2071,7 @@ describe('Address Service', function() {
     });
     it('will pass cache and summary between functions correctly', function(done) {
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2108,6 +2105,7 @@ describe('Address Service', function() {
     });
     it('will log if there is a slow query', function(done) {
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2139,6 +2137,7 @@ describe('Address Service', function() {
   describe('#_getAddressConfirmedSummary', function() {
     it('will pass arguments correctly', function(done) {
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2177,6 +2176,7 @@ describe('Address Service', function() {
     });
     it('will pass error correctly (inputs)', function(done) {
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2200,6 +2200,7 @@ describe('Address Service', function() {
     });
     it('will pass error correctly (outputs)', function(done) {
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2229,6 +2230,7 @@ describe('Address Service', function() {
       var streamStub = new stream.Readable();
       streamStub._read = function() { /* do nothing */ };
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2265,6 +2267,7 @@ describe('Address Service', function() {
       var streamStub = new stream.Readable();
       streamStub._read = function() { /* do nothing */ };
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2296,6 +2299,7 @@ describe('Address Service', function() {
       var streamStub = new stream.Readable();
       streamStub._read = function() { /* do nothing */ };
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub(),
@@ -2350,6 +2354,7 @@ describe('Address Service', function() {
       var streamStub = new stream.Readable();
       streamStub._read = function() { /* do nothing */ };
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2386,6 +2391,7 @@ describe('Address Service', function() {
   describe('#_setAndSortTxidsFromAppearanceIds', function() {
     it('will sort correctly', function(done) {
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2432,6 +2438,7 @@ describe('Address Service', function() {
   describe('#_getAddressMempoolSummary', function() {
     it('skip if options not enabled', function(done) {
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2460,6 +2467,7 @@ describe('Address Service', function() {
     });
     it('include all txids and balance from inputs and outputs', function(done) {
       var testnode = {
+        network: Networks.testnet,
         services: {
           bitcoind: {
             on: sinon.stub()
@@ -2560,6 +2568,7 @@ describe('Address Service', function() {
       unconfirmedBalance: 500000
     };
     var testnode = {
+      network: Networks.testnet,
       services: {
         bitcoind: {
           on: sinon.stub()

--- a/test/services/db.unit.js
+++ b/test/services/db.unit.js
@@ -77,19 +77,7 @@ describe('DB Service', function() {
     });
     it('should load the db with regtest', function() {
       // Switch to use regtest
-      // Networks.remove(Networks.testnet);
-      Networks.add({
-        name: 'regtest',
-        alias: 'regtest',
-        pubkeyhash: 0x6f,
-        privatekey: 0xef,
-        scripthash: 0xc4,
-        xpubkey: 0x043587cf,
-        xprivkey: 0x04358394,
-        networkMagic: 0xfabfb5da,
-        port: 18444,
-        dnsSeeds: [ ]
-      });
+      Networks.enableRegtest();
       var regtest = Networks.get('regtest');
       var config = {
         node: {
@@ -100,7 +88,7 @@ describe('DB Service', function() {
       };
       var db = new DB(config);
       db.dataPath.should.equal(process.env.HOME + '/.bitcoin/regtest/bitcore-node.db');
-      Networks.remove(regtest);
+      Networks.disableRegtest();
     });
   });
 


### PR DESCRIPTION
This adds greater compatibility with regtest for BWS and Copay with a new API from bitcore-lib for regtest: `enableRegtest()` and `disableRegtest()` (see https://github.com/bitpay/bitcore-lib/pull/44).