### PR TITLE
Fix pagination of transaction history

### DIFF
--- a/lib/services/address/history.js
+++ b/lib/services/address/history.js
@@ -119,8 +119,8 @@ AddressHistory.prototype._paginateWithDetails = function(allTxids, callback) {
   // Slice the page starting with the most recent
   var txids;
   if (self.options.from >= 0 && self.options.to >= 0) {
-    var fromOffset = totalCount - self.options.from;
-    var toOffset = totalCount - self.options.to;
+    var fromOffset = Math.max(0, totalCount - self.options.from);
+    var toOffset = Math.max(0, totalCount - self.options.to);
     txids = allTxids.slice(toOffset, fromOffset);
   } else {
     txids = allTxids;


### PR DESCRIPTION
Previously, if paging i.e. from 0 to 100, `toOffset` could easily get negative (because the user does not know the `totalCount` in advance). This should fix this case.