### PR TITLE
bitcoind: relative spawn.datadir handling

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -228,6 +228,7 @@ Node.prototype._startService = function(serviceInfo, callback) {
 Node.prototype._logTitle = function() {
   if (this.configPath) {
     log.info('Using config:', this.configPath);
+    log.info('Using network:', this.getNetworkName());
   }
 };
 

--- a/lib/scaffold/start.js
+++ b/lib/scaffold/start.js
@@ -61,7 +61,6 @@ function checkConfigVersion2(fullConfig) {
  * @param {Object} options.config - The parsed bitcore-node.json configuration file
  * @param {Array}  options.config.services - An array of services names.
  * @param {Object} options.config.servicesConfig - Parameters to pass to each service
- * @param {String} options.config.datadir - A relative (to options.path) or absolute path to the datadir
  * @param {String} options.config.network - 'livenet', 'testnet' or 'regtest
  * @param {Number} options.config.port - The port to use for the web service
  */

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -313,6 +313,15 @@ Bitcoin.prototype._parseBitcoinConf = function(configPath) {
   return options;
 };
 
+Bitcoin.prototype._expandRelativeDatadir = function() {
+  if (!utils.isAbsolutePath(this.options.spawn.datadir)) {
+    $.checkState(this.node.configPath);
+    $.checkState(utils.isAbsolutePath(this.node.configPath));
+    var baseConfigPath = path.dirname(this.node.configPath);
+    this.options.spawn.datadir = path.resolve(baseConfigPath, this.options.spawn.datadir);
+  }
+};
+
 Bitcoin.prototype._loadSpawnConfiguration = function(node) {
   /* jshint maxstatements: 25 */
 
@@ -320,12 +329,7 @@ Bitcoin.prototype._loadSpawnConfiguration = function(node) {
   $.checkArgument(this.options.spawn.datadir, 'Please specify "spawn.datadir" in bitcoind config options');
   $.checkArgument(this.options.spawn.exec, 'Please specify "spawn.exec" in bitcoind config options');
 
-  if (!utils.isAbsolutePath(this.options.spawn.datadir)) {
-    $.checkState(this.node.configPath);
-    $.checkState(utils.isAbsolutePath(this.node.configPath));
-    var baseConfigPath = path.dirname(this.node.configPath);
-    this.options.spawn.datadir = path.resolve(baseConfigPath, this.options.spawn.datadir);
-  }
+  this._expandRelativeDatadir();
 
   var spawnOptions = this.options.spawn;
   var configPath = path.resolve(spawnOptions.datadir, './bitcoin.conf');

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fs = require('fs');
+var path = require('path');
 var spawn = require('child_process').spawn;
 var util = require('util');
 var mkdirp = require('mkdirp');
@@ -16,6 +17,7 @@ var Transaction = bitcore.Transaction;
 var index = require('../');
 var errors = index.errors;
 var log = index.log;
+var utils = require('../utils');
 var Service = require('../service');
 
 /**
@@ -318,8 +320,17 @@ Bitcoin.prototype._loadSpawnConfiguration = function(node) {
   $.checkArgument(this.options.spawn.datadir, 'Please specify "spawn.datadir" in bitcoind config options');
   $.checkArgument(this.options.spawn.exec, 'Please specify "spawn.exec" in bitcoind config options');
 
+  if (!utils.isAbsolutePath(this.options.spawn.datadir)) {
+    $.checkState(this.node.configPath);
+    $.checkState(utils.isAbsolutePath(this.node.configPath));
+    var baseConfigPath = path.dirname(this.node.configPath);
+    this.options.spawn.datadir = path.resolve(baseConfigPath, this.options.spawn.datadir);
+  }
+
   var spawnOptions = this.options.spawn;
-  var configPath = spawnOptions.datadir + '/bitcoin.conf';
+  var configPath = path.resolve(spawnOptions.datadir, './bitcoin.conf');
+
+  log.info('Using bitcoin config file:', configPath);
 
   this.spawn = {};
   this.spawn.datadir = this.options.spawn.datadir;


### PR DESCRIPTION
Will expand the datadir into an absolute path based on the location
of the configuration file. This is to avoid unexpected behavior in regards
to the location of configuration files.

Closes: https://github.com/bitpay/bitcore-node/issues/436
Related: https://forum.bitcore.io/t/v4-install-hangs-at-starting-bitcoind-process/900/20