### PR TITLE
bitcoind: added zmq precondition

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -390,6 +390,11 @@ Bitcoin.prototype._checkConfigIndexes = function(spawnConfig, node) {
       'Please add "zmqpubhashblock=tcp://127.0.0.1:<port>" to your configuration and restart'
   );
 
+  $.checkState(
+    (spawnConfig.zmqpubhashblock === spawnConfig.zmqpubrawtx),
+    '"zmqpubrawtx" and "zmqpubhashblock" are expected to the same host and port in bitcoin.conf'
+  );
+
   if (spawnConfig.reindex && spawnConfig.reindex === 1) {
     log.warn('Reindex option is currently enabled. This means that bitcoind is undergoing a reindex. ' +
              'The reindex flag will start the index from beginning every time the node is started, so it ' +

--- a/test/services/bitcoind.unit.js
+++ b/test/services/bitcoind.unit.js
@@ -429,7 +429,7 @@ describe('Bitcoin Service', function() {
     beforeEach(function() {
       sandbox.stub(log, 'warn');
     });
-    after(function() {
+    afterEach(function() {
       sandbox.restore();
     });
     it('should warn the user if reindex is set to 1 in the bitcoin.conf file', function() {
@@ -447,6 +447,22 @@ describe('Bitcoin Service', function() {
       bitcoind._checkConfigIndexes(config, node);
       log.warn.callCount.should.equal(1);
       node._reindex.should.equal(true);
+    });
+    it('should warn if zmq port and hosts do not match', function() {
+      var bitcoind = new BitcoinService(baseConfig);
+      var config = {
+        txindex: 1,
+        addressindex: 1,
+        spentindex: 1,
+        server: 1,
+        zmqpubrawtx: 'tcp://127.0.0.1:28332',
+        zmqpubhashblock: 'tcp://127.0.0.1:28331',
+        reindex: 1
+      };
+      var node = {};
+      (function() {
+        bitcoind._checkConfigIndexes(config, node);
+      }).should.throw('"zmqpubrawtx" and "zmqpubhashblock"');
     });
   });
 


### PR DESCRIPTION
Adds a state check that transaction and block events are over the same host
and port. This is to make sure that block events can be subscribed to and
that the tip of the chain stays up to date for correct confirmation counts.

Closes: https://github.com/bitpay/insight-api/issues/483