### PR TITLE
bitcoind: get detailed transactions with concurrency

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -76,6 +76,7 @@ Bitcoin.DEFAULT_TRY_ALL_INTERVAL = 1000;
 Bitcoin.DEFAULT_REINDEX_INTERVAL = 10000;
 Bitcoin.DEFAULT_START_RETRY_INTERVAL = 5000;
 Bitcoin.DEFAULT_TIP_UPDATE_INTERVAL = 15000;
+Bitcoin.DEFAULT_TRANSACTION_CONCURRENCY = 5;
 Bitcoin.DEFAULT_CONFIG_SETTINGS = {
   server: 1,
   whitelist: '127.0.0.1',
@@ -92,6 +93,8 @@ Bitcoin.DEFAULT_CONFIG_SETTINGS = {
 };
 
 Bitcoin.prototype._initDefaults = function(options) {
+  /* jshint maxcomplexity: 15 */
+
   // limits
   this.maxTxids = options.maxTxids || Bitcoin.DEFAULT_MAX_TXIDS;
   this.maxTransactionHistory = options.maxTransactionHistory || Bitcoin.DEFAULT_MAX_HISTORY;
@@ -105,6 +108,9 @@ Bitcoin.prototype._initDefaults = function(options) {
   // try all interval
   this.tryAllInterval = options.tryAllInterval || Bitcoin.DEFAULT_TRY_ALL_INTERVAL;
   this.startRetryInterval = options.startRetryInterval || Bitcoin.DEFAULT_START_RETRY_INTERVAL;
+
+  // rpc limits
+  this.transactionConcurrency = options.transactionConcurrency || Bitcoin.DEFAULT_TRANSACTION_CONCURRENCY;
 
   // sync progress level when zmq subscribes to events
   this.zmqSubscribeProgress = options.zmqSubscribeProgress || Bitcoin.DEFAULT_ZMQ_SUBSCRIBE_PROGRESS;
@@ -1412,8 +1418,9 @@ Bitcoin.prototype.getAddressHistory = function(addressArg, options, callback) {
       return callback(e);
     }
 
-    async.mapSeries(
+    async.mapLimit(
       txids,
+      self.transactionConcurrency,
       function(txid, next) {
         self._getAddressDetailedTransaction(txid, {
           queryMempool: queryMempool,

--- a/test/services/bitcoind.unit.js
+++ b/test/services/bitcoind.unit.js
@@ -83,6 +83,16 @@ describe('Bitcoin Service', function() {
     });
   });
 
+  describe('#_initDefaults', function() {
+    it('will set transaction concurrency', function() {
+      var bitcoind = new BitcoinService(baseConfig);
+      bitcoind._initDefaults({transactionConcurrency: 10});
+      bitcoind.transactionConcurrency.should.equal(10);
+      bitcoind._initDefaults({});
+      bitcoind.transactionConcurrency.should.equal(5);
+    });
+  });
+
   describe('@dependencies', function() {
     it('will have no dependencies', function() {
       BitcoinService.dependencies.should.deep.equal([]);


### PR DESCRIPTION
increase performance of querying address history by executing multiple
rpc calls concurrently with configurable limit