### PR TITLE
bitcoind: connect option for strict ssl

### DIFF
--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -925,7 +925,8 @@ Bitcoin.prototype._connectProcess = function(config, callback) {
       host: config.rpchost || '127.0.0.1',
       port: config.rpcport,
       user: config.rpcuser,
-      pass: config.rpcpassword
+      pass: config.rpcpassword,
+      rejectUnauthorized: _.isUndefined(config.rpcstrict) ? true : config.rpcstrict
     });
 
     self._loadTipFromNode(node, done);


### PR DESCRIPTION
This is to be able to configure the RPC client to handle self-signed
certificates for development purposes.