### PR TITLE
Add option to query **only** mempool

### DIFF
--- a/docs/services/bitcoind.md
+++ b/docs/services/bitcoind.md
@@ -217,12 +217,16 @@ node.services.bitcoind.getAddressBalance(address, options, function(err, balance
 
 This method will give history of an address limited by a range of block heights by using the "start" and "end" arguments. The "start" value is the more recent, and greater, block height. The "end" value is the older, and lesser, block height. This feature is most useful for synchronization as previous history can be omitted. Furthermore for large ranges of block heights, results can be paginated by using the "from" and "to" arguments.
 
+If "queryMempool" is set as true (it is true by default), it will show unconfirmed transactions from the bitcoin mempool. However, if you specify "start" and "end", "queryMempool" is ignored and is always false.
+
+If "queryMempoolOnly" is set as true (it is false by default), it will show *only* unconfirmed transactions from mempool.
+
 ```js
 var addresses = ['mgY65WSfEmsyYaYPQaXhmXMeBhwp4EcsQW'];
 var options = {
   start: 345000,
   end: 344000,
-  queryMempool: true
+  queryMempool: true // since we presented range, queryMempool will be ignored
 };
 node.services.bitcoind.getAddressHistory(addresses, options, function(err, history) {
   // see below

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -1208,7 +1208,7 @@ Bitcoin.prototype._getHeightRangeQuery = function(options, clone) {
  * @param {Function} callback
  */
 Bitcoin.prototype.getAddressTxids = function(addressArg, options, callback) {
-  /* jshint maxstatements: 16 */
+  /* jshint maxstatements: 20 */
   var self = this;
   var queryMempool = _.isUndefined(options.queryMempool) ? true : options.queryMempool;
   var queryMempoolOnly = _.isUndefined(options.queryMempoolOnly) ? false : options.queryMempoolOnly;

--- a/lib/services/bitcoind.js
+++ b/lib/services/bitcoind.js
@@ -1211,6 +1211,7 @@ Bitcoin.prototype.getAddressTxids = function(addressArg, options, callback) {
   /* jshint maxstatements: 16 */
   var self = this;
   var queryMempool = _.isUndefined(options.queryMempool) ? true : options.queryMempool;
+  var queryMempoolOnly = _.isUndefined(options.queryMempoolOnly) ? false : options.queryMempoolOnly;
   var rangeQuery = false;
   try {
     rangeQuery = self._getHeightRangeQuery(options);
@@ -1220,12 +1221,21 @@ Bitcoin.prototype.getAddressTxids = function(addressArg, options, callback) {
   if (rangeQuery) {
     queryMempool = false;
   }
+  if (queryMempoolOnly) {
+    queryMempool = true;
+    rangeQuery = false;
+  }
   var addresses = self._normalizeAddressArg(addressArg);
   var cacheKey = addresses.join('');
   var mempoolTxids = [];
-  var txids = self.txidsCache.get(cacheKey);
+  var txids = queryMempoolOnly ? false : self.txidsCache.get(cacheKey);
 
   function finish() {
+    if (queryMempoolOnly) {
+      return setImmediate(function() {
+        callback(null, mempoolTxids.reverse());
+      });
+    }
     if (txids && !rangeQuery) {
       var allTxids = mempoolTxids.reverse().concat(txids);
       return setImmediate(function() {

--- a/test/services/bitcoind.unit.js
+++ b/test/services/bitcoind.unit.js
@@ -3070,7 +3070,19 @@ describe('Bitcoin Service', function() {
             'bc992ad772eb02864db07ef248d31fb3c6826d25f1153ebf8c79df9b7f70fcf2', // mempool
             'e9dcf22807db77ac0276b03cc2d3a8b03c4837db8ac6650501ef45af1c807cce' // confirmed
           ]);
-          done();
+
+          bitcoind.getAddressTxids(address, {queryMempoolOnly: true}, function(err, txids) {
+            if (err) {
+              return done(err);
+            }
+            getAddressTxids.callCount.should.equal(1);
+            txids.should.deep.equal([
+              'f35e7e2a2334e845946f3eaca76890d9a68f4393ccc9fe37a0c2fb035f66d2e9', // mempool
+              'f71bccef3a8f5609c7f016154922adbfe0194a96fb17a798c24077c18d0a9345', // mempool
+              'bc992ad772eb02864db07ef248d31fb3c6826d25f1153ebf8c79df9b7f70fcf2', // mempool
+            ]);
+            done();
+          });
         });
       });
     });


### PR DESCRIPTION
Related to https://github.com/bitpay/bitcore-node/issues/484

Sometimes I want to get only the unconfirmed transactions from mempool.

The new option `queryMempoolOnly` is also "propagated" to other calls too - like `getTransactionHistory`.