### PR TITLE
Use bitcore-lib as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "async": "^1.3.0",
     "bitcoind-rpc": "^0.6.0",
-    "bitcore-lib": "^0.13.13",
     "body-parser": "^1.13.3",
     "colors": "^1.1.2",
     "commander": "^2.8.1",
@@ -77,6 +76,9 @@
     "proxyquire": "^1.3.1",
     "rimraf": "^2.4.2",
     "sinon": "^1.15.4"
+  },
+  "peerDependencies": {
+    "bitcore-lib": "^0.14"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
One wrinkle to using the bitcore stack is the obvious need to have a singleton `bitcore-lib`.  The `bitcoin-lib` package hosts the `bitcoind` library and there are good reasons to not wanting to have multiple `bitcoind` instances running on the same machine.

However, I am not a fan of the runtime check and would rather have all packages be declaring `bitcoin-lib` in `peerDependencies`.  This way the enclosing package can specify whatever version of `bitcoin-lib` it wants and `npm` will inform user if there is an unmet dependency at _install_ time rather than _run_ time.

I have a working example of `bitcore-lib` running as a peerDependency at  [bitcore-docker-build](https://github.com/CaptEmulation/bitcore-docker-build) which is also running testnet at [bitcore.soapbubble.online](https://bitcore.soapbubble.online)

I also updated `bitcore-lib` to 0.14 because `bitcore-wallet-service` has already done so and I figured if it was good enough for `bitcoin-wallet-service` it's good enough for everything else :smile: 