### PR TITLE
Updated fee service and cleaned console log from header service

### DIFF
--- a/lib/services/fee/index.js
+++ b/lib/services/fee/index.js
@@ -10,7 +10,7 @@ var FeeService = function(options) {
     pass: 'local321',
     host: 'localhost',
     protocol: 'http',
-    port: 8333
+    port: 8332
   };
   BaseService.call(this, options);
 

--- a/lib/services/fee/index.js
+++ b/lib/services/fee/index.js
@@ -10,7 +10,7 @@ var FeeService = function(options) {
     pass: 'local321',
     host: 'localhost',
     protocol: 'http',
-    port: this._getDefaultPort()
+    port: 8333
   };
   BaseService.call(this, options);
 
@@ -34,8 +34,7 @@ FeeService.prototype.stop = function(callback) {
 
 FeeService.prototype.getAPIMethods = function() {
   return [
-    ['estimateFee', this, this.estimateFee, 1],
-    ['syncPercentage', this, this.syncPercentage, 0]
+    ['estimateFee', this, this.estimateFee, 1]
   ];
 };
 

--- a/lib/services/header/index.js
+++ b/lib/services/header/index.js
@@ -34,8 +34,6 @@ HeaderService.STARTING_CHAINWORK = '00000000000000000000000000000000000000000000
 
 // --- public prototype functions
 HeaderService.prototype.subscribe = function(name, emitter) {
-
-console.log(this.subscriptions, name);
   this.subscriptions[name].push(emitter);
   log.info(emitter.remoteAddress, 'subscribe:', 'header/' + name, 'total:', this.subscriptions[name].length);
 

--- a/test/services/fee/index.unit.js
+++ b/test/services/fee/index.unit.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var sinon = require('sinon');
+var FeeService = require('../../../lib/services/fee');
+
+var expect = require('chai').expect;
+
+describe.only('#Fee Service', function() {
+  var feeService;
+  var sandbox;
+  beforeEach(function() {
+    sandbox = sinon.sandbox.create();
+    feeService = new FeeService({
+      "rpc": {
+        "user": "bitcoin",
+        "pass": "local321",
+        "host": "localhost",
+        "protocol": "http",
+        "port": 8332
+      }
+    });
+  });
+
+  afterEach(function() {
+    sandbox.restore();
+  });
+
+  /*
+    Running in regtest mode or unsync'd will return -1
+  */
+
+  it("Has an estimateFee method", function() {
+    var method = feeService.getAPIMethods()[0][0];
+    expect(method).to.equal('estimateFee');
+  })
+
+  it("Can estimate fees", function(done) {
+    feeService.estimateFee(4, function(err, fee) {
+      expect(err).to.be.a('null');
+      expect(fee.result).to.exist;
+      expect(fee.result).to.be.at.least(-1);
+      done();
+    });
+  })
+
+
+});


### PR DESCRIPTION
Fee service will defer to bitcore-node.json for its config. Define fee.rpc under servicesConfig

```
"servicesConfig": {
    "fee": {
      "rpc": {
        "user": "btcrpc",
        "pass": "dontusethisyouwillberobbed-maybe",
        "host": "localhost",
        "protocol": "http",
        "port": 8333
      }
    }
  }
```

syncPercentage is provided by another service and its implementation is gone so I've removed that from the fee service API.

Cleaned a console.log from the header service

