### PR TITLE
Return version from package.json on CLI, fixes #415 and bitpay/bitcore#1368

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,4 +23,6 @@ module.exports.cli.daemon = require('./lib/cli/daemon');
 module.exports.cli.bitcore = require('./lib/cli/bitcore');
 module.exports.cli.bitcored = require('./lib/cli/bitcored');
 
+module.exports.version = require('./package.json').version;
+
 module.exports.lib = require('bitcore-lib');


### PR DESCRIPTION
One might argue that reading version numbers from package.json isn't good style and may have security implications (https://stackoverflow.com/a/10855054), but I don't see any problems here. 

This fixes #415 and should fix bitpay/bitcore#1368 (though I haven't tested the latter).