### PR TITLE
fix history sorting when paging results

### DIFF
--- a/lib/services/address/index.js
+++ b/lib/services/address/index.js
@@ -79,7 +79,7 @@ AddressService.prototype.getAddressHistory = function(addresses, options, callba
     });
 
 
-    options.txIdList = lodash.sortBy(list,['height','txid']);
+    options.txIdList = lodash.orderBy(list,['height','txid'], ['desc','asc']);
     self._getAddressTxHistory(options, function(err, txList) {
 
       if (err) {

--- a/lib/services/address/index.js
+++ b/lib/services/address/index.js
@@ -66,7 +66,6 @@ AddressService.prototype.getAddressHistory = function(addresses, options, callba
   }
 
   async.eachLimit(addresses, 4, function(address, next) {
-
     self._getAddressTxidHistory(address, options, next);
 
   }, function(err) {
@@ -75,21 +74,12 @@ AddressService.prototype.getAddressHistory = function(addresses, options, callba
       return callback(err);
     }
 
-    var unique = {};
-    var list = [];
-
-    for (let i = 0; i < options.txIdList.length; i++) {
-      unique[options.txIdList[i].txid + options.txIdList[i].height] = options.txIdList[i];
-    }
-
-    for (var prop in unique) {
-      list.push(unique[prop]);
-    }
-
-    options.txIdList = list.sort(function(a, b) {
-     return b.height - a.height;
+    var list = lodash.uniqBy(options.txIdList, function(x) { 
+      return x.txid + x.height;
     });
 
+
+    options.txIdList = lodash.sortBy(list,['height','txid']);
     self._getAddressTxHistory(options, function(err, txList) {
 
       if (err) {
@@ -427,7 +417,6 @@ AddressService.prototype._getAddressTxHistory = function(options, callback) {
 };
 
 AddressService.prototype._getAddressTxidHistory = function(address, options, callback) {
-
   var self = this;
 
   options = options || {};

--- a/test/services/address/index.unit.js
+++ b/test/services/address/index.unit.js
@@ -81,19 +81,19 @@ describe('Address Service', function() {
       addressService._getAddressTxidHistory = function(addr, options, cb) {
         options.txIdList = [
           {
-            txid: "b",
+            txid: "d",
+            height: 10,
+          },
+          {
+            txid: "c",
             height: 10,
           },
           {
             txid: "a",
-            height: 10,
-          },
-          {
-            txid: "d",
             height: 101,
           },
           {
-            txid: "c",
+            txid: "b",
             height: 100,
           },
         ];
@@ -163,7 +163,7 @@ describe('Address Service', function() {
         }
 
         expect(res.totalCount).equal(3);
-        expect(lodash.map(res.items,'txid')).to.be.deep.equal(['b','c','d']);
+        expect(lodash.map(res.items,'txid')).to.be.deep.equal(['d','c','b']);
 
         addressService._getAddressTxidHistory = old_getAddressTxHistory;
         addressService._getAddressTxHistory = old_getAddressTxHistory;


### PR DESCRIPTION
Add 'txid' as a sorting keyword for result pages.