### PR TITLE
add txIdList cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Note: A default configuration file is placed in the bitcore user's home director
 - ~500GB of disk storage
 - ~4GB of RAM
 
+
 ## Configuration
 
 The main configuration file is called "bitcore-node.json". This file instructs bitcore-node for the following options:


### PR DESCRIPTION
adds a txIdList LRU cache when the client downloads txHistory.
allows the client to send the cache key instead of the complete address list.
used XXhash 32 bit for fash addressed hashing (non cryptographic hashing)