### PR TITLE
Node 8: Add legacy API endpoints

### DIFF
--- a/src/providers/chain-state/index.ts
+++ b/src/providers/chain-state/index.ts
@@ -49,6 +49,10 @@ class ChainStateProxy implements CSP.ChainStateProvider {
     return this.get(params).streamTransaction(params);
   }
 
+  streamTransactionRaw(params: CSP.StreamTransactionParams) {
+    return this.get(params).streamTransactionRaw(params);
+  }
+
   async createWallet(params: CSP.CreateWalletParams) {
     return this.get(params).createWallet(params);
   }

--- a/src/providers/chain-state/internal/internal.ts
+++ b/src/providers/chain-state/internal/internal.ts
@@ -150,11 +150,22 @@ export class InternalStateProvider implements CSP.IChainStateService {
     if (typeof txId !== 'string' || !this.chain || !network || !stream) {
       throw 'Missing required param';
     }
-    network = network.toLowerCase();
+    network = network.toLowerCase();           
     let query = { chain: this.chain, network, txid: txId };
     TransactionModel.getTransactions({ query })
-      .pipe(JSONStream.stringify())
-      .pipe(stream);
+    .pipe(JSONStream.stringify())
+    .pipe(stream);
+  }
+
+  streamTransactionRaw(params: CSP.StreamTransactionParams) {
+    let { network, txId, stream } = params;
+    if (typeof txId !== 'string' || !this.chain || !network || !stream) {
+      throw 'Missing required param';
+    }
+    this.getRPC(network).getTransaction(txId, true, (_: any, result: any) => {
+    const transaction = typeof result !== "undefined" ? {rawTx : result.hex} : [];
+    stream.send(JSON.stringify(transaction));
+    });
   }
 
   async createWallet(params: CSP.CreateWalletParams) {

--- a/src/routes/block.ts
+++ b/src/routes/block.ts
@@ -21,6 +21,25 @@ router.get("/", async function(req: Request, res: Response) {
   }
 });
 
+router.get("/latest", async function(req: Request, res: Response) {
+    let { chain, network, sinceBlock } = req.params;
+    try {
+      let payload = {
+        chain,
+        network,
+        sinceBlock,
+        args: { limit: 1 }
+      };
+      let block = await ChainStateProvider.getBlocks(payload);
+      if (!block) {
+        return res.status(404).send("block not found");
+      }
+      return res.json(block);
+    } catch (err) {
+      return res.status(500).send(err);
+    }
+  });
+
 router.get("/:blockId", async function(req: Request, res: Response) {
   let { blockId, chain, network } = req.params;
   try {

--- a/src/routes/tx.ts
+++ b/src/routes/tx.ts
@@ -36,6 +36,16 @@ router.get('/:txId', function(req, res) {
   return ChainStateProvider.streamTransaction({ chain, network, txId, stream: res });
 });
 
+router.get('/:txId/raw', function(req, res) {
+    let { chain, network, txId } = req.params;
+    if (typeof txId !== 'string' || !chain || !network) {
+      return res.status(400).send('Missing required param');
+    }
+    chain = chain.toUpperCase();
+    network = network.toLowerCase();
+    return ChainStateProvider.streamTransactionRaw({ chain, network, txId, stream: res });
+  });
+
 router.post('/send', async function(req, res) {
   try {
     let { chain, network } = req.params;

--- a/src/rpc.ts
+++ b/src/rpc.ts
@@ -75,9 +75,9 @@ export class RPC {
     });
   }
 
-  getTransaction(txid: string, callback: CallbackType) {
+  getTransaction(txid: string, verbose:boolean, callback: CallbackType) {
     var self = this;
-    self.callMethod('getrawtransaction', [txid, true], function(err, result) {
+    self.callMethod('getrawtransaction', [txid, verbose], function(err, result) {
       if (err) {
         return callback(err);
       }

--- a/src/types/namespaces/ChainStateProvider.ts
+++ b/src/types/namespaces/ChainStateProvider.ts
@@ -89,6 +89,7 @@ export declare namespace CSP {
     updateWallet(params: UpdateWalletParams): Promise<IWalletModel>;
     getWalletBalance(params: GetWalletBalanceParams): Promise<{balance: number}[]>;
     streamAddressUtxos(params: StreamAddressUtxosParams): any;
+    streamTransactionRaw(params: StreamTransactionParams): any;
     streamTransactions(params: StreamTransactionsParams): any;
     streamTransaction(params: StreamTransactionParams): any;
     streamWalletAddresses(params: StreamWalletAddressesParams): any;


### PR DESCRIPTION
This will add some of the endpoints that were not added in v8, but were in v3-v5.

+ Added `api/tx/:txid/raw` to get the raw hex value of the transaction specified by `txid`
+ Added `api/block/latest` to get the latest block stored on the bitcore-node of the specified blockchain.